### PR TITLE
feat: add dealership simulator monorepo

### DIFF
--- a/dealership-sim/.eslintrc.cjs
+++ b/dealership-sim/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'react'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  ignorePatterns: ['dist', 'build', 'node_modules'],
+};

--- a/dealership-sim/.gitignore
+++ b/dealership-sim/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+pnpm-lock.yaml
+dist
+build
+.DS_Store
+.env
+backend/data/save.json

--- a/dealership-sim/.prettierrc
+++ b/dealership-sim/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/dealership-sim/LICENSE
+++ b/dealership-sim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Dealership Simulator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dealership-sim/README.md
+++ b/dealership-sim/README.md
@@ -1,0 +1,84 @@
+# Dealership Simulator
+
+A tick-based idle/management simulator where you run a BMW/MINI inspired dealership. Monitor sales, service, inventory, morale, and balancing coefficients in real time while keeping the store profitable.
+
+## Quick Start
+
+```bash
+pnpm install
+pnpm dev
+```
+
+- Backend available at http://localhost:4000
+- Frontend dashboard at http://localhost:5173
+
+### Additional scripts
+
+| Command | Description |
+| --- | --- |
+| `pnpm build` | Build all workspaces |
+| `pnpm test` | Run backend Jest tests and frontend Vitest suites |
+| `pnpm lint` | Run ESLint on all packages |
+| `pnpm format` | Run Prettier across the repo |
+
+Create a `.env` file in `backend/` if you need to customise `PORT`, `SEED_MODE`, `SAVE_PATH`, or `TICK_INTERVAL_MS` (see `.env.example`).
+
+## Game Manual
+
+- **Time** – Each tick advances one simulated day. Use the ticker controls (Pause/Play, 1x/5x/30x, Step Day) to manage pacing.
+- **Sales Funnel** – Leads flow to appointments and deals. Advisor morale and archetypes influence close rate, CSI, and gross.
+- **Inventory** – Vehicles age daily, depreciate, and auto-replenish when days-supply drops below thresholds. Use the Acquire panel for manual bulk buys.
+- **Service** – Technician efficiency and morale drive hours billed. Comebacks reduce CSI which feeds future demand.
+- **Marketing** – Adjust spend to increase lead flow with diminishing returns. Economy events (incentives, weather, audits) adjust demand.
+- **Finance** – Cash updates daily from sales and fixed ops. Guardrails ensure expected gross supports future restocking; warnings appear if starvation risk rises.
+
+### Control Panel Cheat Sheet
+
+- **Presets** – Easy/Balanced/Hard/Wild adjust key coefficients instantly.
+- **Marketing & Lead Generation** – Tune lead volume and diminishing returns, plus daily marketing spend.
+- **Sales Tuning** – Adjust how desirability, pricing, economy, and archetypes affect closing probability.
+- **Inventory & Pricing** – Control days supply guardrails, auction spreads, and pricing variance.
+- **Health Check** – Real-time warning when expected gross falls below replacement needs.
+
+### Save & Load
+
+- `POST /api/save` writes the current state to `backend/data/save.json` (or custom `SAVE_PATH`).
+- `POST /api/load` reloads from disk. The server auto-saves at each scheduled tick when `SAVE_PATH` is configured.
+
+## Tech Stack
+
+- **Frontend**: React + TypeScript, Vite, Zustand, TailwindCSS, shadcn-inspired UI primitives, Recharts, lucide-react icons.
+- **Backend**: Node + TypeScript, Express, Jest. Tick-based simulation engine with repository pattern and optional JSON persistence.
+- **Shared**: Common type system and default balancing constants shared across packages.
+- **Tooling**: pnpm workspaces, ESLint, Prettier, Vitest, Jest.
+
+### Architecture Overview
+
+```
+┌────────────────────────┐       ┌────────────────────────┐
+│        Frontend        │  API  │        Backend         │
+│  React + Zustand store │◄─────►│ Express + Simulation   │
+│  Dashboard & Features  │       │ Engine + Repository    │
+└─────────▲──────────────┘       └─────────▲──────────────┘
+          │                                │
+          │                                │
+          ▼                                ▼
+  ┌──────────────┐              ┌──────────────────┐
+  │  shared/     │◄────────────►│  In-memory state │
+  │  types + cfg │              │  JSON persistence│
+  └──────────────┘              └──────────────────┘
+```
+
+## Balancing Notes
+
+- Lead generation uses `lead.basePerDay * demandIndex * (1 + marketingK * ln(1 + spendPerDay))`.
+- Closing probability runs through a sigmoid across advisor skill, customer bias, desirability, price fit, and economy.
+- Guardrail health check compares expected front/back gross to target replacement gross, warning when inventory starvation is likely.
+- Service production scales with technician efficiency and morale; comebacks impact CSI which feeds future demand multipliers.
+
+## Testing
+
+- Backend Jest suite covers engine determinism, guardrails, inventory cash checks, sales desirability monotonicity, service CSI impacts, and config validation.
+- Frontend Vitest suite ensures key dashboard KPIs render.
+
+Enjoy running the store — keep the cash flowing, morale high, and CSI climbing!

--- a/dealership-sim/backend/.env.example
+++ b/dealership-sim/backend/.env.example
@@ -1,0 +1,4 @@
+PORT=4000
+SEED_MODE=reset
+SAVE_PATH=./data/save.json
+TICK_INTERVAL_MS=1000

--- a/dealership-sim/backend/data/.gitignore
+++ b/dealership-sim/backend/data/.gitignore
@@ -1,0 +1,1 @@
+save.json

--- a/dealership-sim/backend/jest.config.js
+++ b/dealership-sim/backend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^@dealership/shared(.*)$': '<rootDir>/../shared/src$1'
+  }
+};

--- a/dealership-sim/backend/package.json
+++ b/dealership-sim/backend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@dealership/backend",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,json,md}'",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@dealership/shared": "workspace:*",
+    "cors": "2.8.5",
+    "express": "4.18.2",
+    "zod": "3.22.2",
+    "uuid": "9.0.1",
+    "dayjs": "1.11.10"
+  },
+  "devDependencies": {
+    "@types/express": "4.17.21",
+    "@types/node": "20.11.17",
+    "@types/cors": "2.8.15",
+    "@types/jest": "29.5.11",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.3.3",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "supertest": "6.3.3",
+    "@types/supertest": "2.0.16",
+    "eslint": "8.56.0",
+    "@typescript-eslint/parser": "6.13.1",
+    "@typescript-eslint/eslint-plugin": "6.13.1",
+    "prettier": "3.1.1"
+  }
+}

--- a/dealership-sim/backend/src/__tests__/coefficients.test.ts
+++ b/dealership-sim/backend/src/__tests__/coefficients.test.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_COEFFICIENTS } from '@dealership/shared';
+import { healthCheck, mergeCoefficients } from '../core/balance/coefficients';
+import { createSeedState } from '../data/seed';
+
+describe('Coefficient guardrails', () => {
+  it('flags starvation when replacement cost too high', () => {
+    const state = createSeedState();
+    const hostile = mergeCoefficients(DEFAULT_COEFFICIENTS, {
+      finance: { avgBackGross: 100 },
+      pricing: { variancePct: 0.12 },
+      guardrails: { targetReplacementGross: 6000 },
+    });
+    const result = healthCheck(state.inventory, hostile);
+    expect(result.starving).toBe(true);
+  });
+});

--- a/dealership-sim/backend/src/__tests__/configRoutes.test.ts
+++ b/dealership-sim/backend/src/__tests__/configRoutes.test.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import request from 'supertest';
+import { createSeedState } from '../data/seed';
+import { GameRepository } from '../core/repository/gameRepository';
+import { SimulationEngine } from '../core/engine/loop';
+import configRoutes from '../routes/config';
+
+const createApp = () => {
+  const app = express();
+  app.use(express.json());
+  const repository = new GameRepository(createSeedState());
+  const engine = new SimulationEngine(repository, { seed: 5 });
+
+  app.use((req, _res, next) => {
+    (req as any).engine = engine;
+    (req as any).repository = repository;
+    (req as any).schedule = () => undefined;
+    next();
+  });
+
+  app.use('/api', configRoutes);
+  return app;
+};
+
+describe('Config routes', () => {
+  it('rejects invalid coefficient payloads', async () => {
+    const app = createApp();
+    const response = await request(app).put('/api/config').send({ lead: { basePerDay: 500 } });
+    expect(response.status).toBe(400);
+  });
+});

--- a/dealership-sim/backend/src/__tests__/engine.test.ts
+++ b/dealership-sim/backend/src/__tests__/engine.test.ts
@@ -1,0 +1,21 @@
+import { GameRepository } from '../core/repository/gameRepository';
+import { SimulationEngine } from '../core/engine/loop';
+import { createSeedState } from '../data/seed';
+
+describe('SimulationEngine', () => {
+  it('produces deterministic results with fixed seed', () => {
+    const seedStateA = createSeedState(99);
+    const seedStateB = createSeedState(99);
+    const repoA = new GameRepository(seedStateA);
+    const repoB = new GameRepository(seedStateB);
+    const engineA = new SimulationEngine(repoA, { seed: 123 });
+    const engineB = new SimulationEngine(repoB, { seed: 123 });
+
+    const resultA = engineA.tick(5);
+    const resultB = engineB.tick(5);
+
+    expect(resultA.cash).toBeCloseTo(resultB.cash);
+    expect(resultA.inventory.length).toEqual(resultB.inventory.length);
+    expect(resultA.recentDeals.length).toEqual(resultB.recentDeals.length);
+  });
+});

--- a/dealership-sim/backend/src/__tests__/inventory.test.ts
+++ b/dealership-sim/backend/src/__tests__/inventory.test.ts
@@ -1,0 +1,12 @@
+import { autoRestock } from '../core/services/inventory';
+import { createSeedState } from '../data/seed';
+import { RNG } from '../utils/random';
+
+describe('Inventory restock', () => {
+  it('does not restock when cash is insufficient', () => {
+    const state = createSeedState();
+    const result = autoRestock(state.inventory, 1000, state.coefficients, new RNG(1), 5);
+    expect(result.newVehicles).toHaveLength(0);
+    expect(result.cashSpent).toBe(0);
+  });
+});

--- a/dealership-sim/backend/src/__tests__/sales.test.ts
+++ b/dealership-sim/backend/src/__tests__/sales.test.ts
@@ -1,0 +1,28 @@
+import { __testing } from '../core/services/sales';
+import { createSeedState } from '../data/seed';
+
+const { computeClosingProbability } = __testing;
+
+describe('Sales closing probability', () => {
+  it('increases with desirability', () => {
+    const state = createSeedState();
+    const advisor = state.advisors[0];
+    const customer = {
+      id: 'c1',
+      type: 'Test',
+      priceSensitivity: 0.5,
+      paymentFocus: 0.5,
+      channel: 'web' as const,
+      loyalty: 0.5,
+      closeBias: 0,
+      grossBias: 0,
+      csiBias: 0,
+      bevAffinity: 0,
+    };
+    const lowCar = { ...state.inventory[0], desirability: 30 };
+    const highCar = { ...state.inventory[0], desirability: 90 };
+    const low = computeClosingProbability(advisor, customer, lowCar, state.economy, state.coefficients);
+    const high = computeClosingProbability(advisor, customer, highCar, state.economy, state.coefficients);
+    expect(high).toBeGreaterThan(low);
+  });
+});

--- a/dealership-sim/backend/src/__tests__/service.test.ts
+++ b/dealership-sim/backend/src/__tests__/service.test.ts
@@ -1,0 +1,19 @@
+import { runServiceDepartment } from '../core/services/service';
+import { createSeedState } from '../data/seed';
+import { RNG } from '../utils/random';
+
+describe('Service department', () => {
+  it('records comeback penalty impact', () => {
+    const state = createSeedState();
+    const queue = Array.from({ length: 5 }).map((_, index) => ({
+      id: `job-${index}`,
+      status: 'waiting' as const,
+      laborHours: 3,
+      partsRevenue: 0,
+      comebackRisk: 0.2,
+    }));
+    const result = runServiceDepartment(state.technicians, queue, 5, new RNG(3));
+    expect(result.completed.length).toBeGreaterThan(0);
+    expect(result.csiDelta).toBeLessThanOrEqual(50);
+  });
+});

--- a/dealership-sim/backend/src/core/balance/archetypes.ts
+++ b/dealership-sim/backend/src/core/balance/archetypes.ts
@@ -1,0 +1,216 @@
+export interface AdvisorArchetype {
+  id: string;
+  name: string;
+  description: string;
+  modifiers: {
+    close: number;
+    gross: number;
+    csi: number;
+    speed: number;
+    bevAffinity: number;
+    backGross: number;
+  };
+}
+
+export interface TechnicianArchetype {
+  id: string;
+  name: string;
+  description: string;
+  modifiers: {
+    efficiency: number;
+    comebackRate: number;
+    moraleSensitivity: number;
+    bevCapture: number;
+  };
+}
+
+export interface CustomerArchetype {
+  id: string;
+  name: string;
+  description: string;
+  modifiers: {
+    closeBias: number;
+    grossBias: number;
+    csiBias: number;
+    bevAffinity: number;
+    priceSensitivity: number;
+    loyalty: number;
+  };
+}
+
+export const ADVISOR_ARCHETYPES: AdvisorArchetype[] = [
+  {
+    id: 'closer',
+    name: 'Closer',
+    description: 'Relentless negotiator, high close rate with CSI trade-off.',
+    modifiers: { close: 0.18, gross: 0.1, csi: -0.1, speed: -0.05, bevAffinity: -0.05, backGross: 0.04 },
+  },
+  {
+    id: 'relationship-builder',
+    name: 'Relationship Builder',
+    description: 'Prioritizes long-term satisfaction.',
+    modifiers: { close: 0.06, gross: 0, csi: 0.15, speed: -0.02, bevAffinity: 0, backGross: 0.02 },
+  },
+  {
+    id: 'tech-geek',
+    name: 'Tech Geek',
+    description: 'EV evangelist with product mastery.',
+    modifiers: { close: 0.08, gross: -0.03, csi: 0.05, speed: -0.01, bevAffinity: 0.2, backGross: 0.03 },
+  },
+  {
+    id: 'grinder',
+    name: 'Grinder',
+    description: 'Works every deal for maximum gross.',
+    modifiers: { close: 0.02, gross: 0.18, csi: -0.05, speed: -0.08, bevAffinity: 0, backGross: 0.05 },
+  },
+  {
+    id: 'charmer',
+    name: 'Charmer',
+    description: 'High energy, keeps appointments and CSI high.',
+    modifiers: { close: 0.1, gross: -0.04, csi: 0.1, speed: 0.08, bevAffinity: 0.05, backGross: 0.01 },
+  },
+  {
+    id: 'rookie',
+    name: 'Rookie',
+    description: 'Learning quickly but currently underperforming.',
+    modifiers: { close: -0.06, gross: -0.08, csi: -0.02, speed: -0.05, bevAffinity: 0, backGross: -0.04 },
+  },
+  {
+    id: 'process-pro',
+    name: 'Process Pro',
+    description: 'Consistent and reliable performer.',
+    modifiers: { close: 0.07, gross: 0.04, csi: 0.03, speed: 0, bevAffinity: 0.02, backGross: 0.02 },
+  },
+  {
+    id: 'high-energy',
+    name: 'High Energy',
+    description: 'Volume machine with thinner deals.',
+    modifiers: { close: 0.12, gross: -0.09, csi: -0.02, speed: 0.15, bevAffinity: 0.03, backGross: -0.02 },
+  },
+  {
+    id: 'finance-whisperer',
+    name: 'Finance Whisperer',
+    description: 'Excels at back-end products.',
+    modifiers: { close: 0.05, gross: 0.02, csi: 0, speed: -0.03, bevAffinity: 0, backGross: 0.16 },
+  },
+  {
+    id: 'slacker',
+    name: 'Slacker',
+    description: 'Low activity and engagement.',
+    modifiers: { close: -0.08, gross: -0.06, csi: -0.08, speed: -0.12, bevAffinity: -0.05, backGross: -0.06 },
+  },
+];
+
+export const TECH_ARCHETYPES: TechnicianArchetype[] = [
+  {
+    id: 'master-tech',
+    name: 'Master Tech',
+    description: 'High efficiency and low comebacks.',
+    modifiers: { efficiency: 0.25, comebackRate: -0.05, moraleSensitivity: 0.1, bevCapture: 0.05 },
+  },
+  {
+    id: 'flat-rate-rocket',
+    name: 'Flat-Rate Rocket',
+    description: 'Cranks hours with some quality risk.',
+    modifiers: { efficiency: 0.35, comebackRate: 0.06, moraleSensitivity: -0.05, bevCapture: 0 },
+  },
+  {
+    id: 'diagnostic-ace',
+    name: 'Diagnostic Ace',
+    description: 'Solves complex issues efficiently.',
+    modifiers: { efficiency: 0.15, comebackRate: -0.03, moraleSensitivity: 0.05, bevCapture: 0.07 },
+  },
+  {
+    id: 'apprentice',
+    name: 'Apprentice',
+    description: 'Still learning but motivated.',
+    modifiers: { efficiency: -0.2, comebackRate: 0.04, moraleSensitivity: 0.08, bevCapture: 0 },
+  },
+  {
+    id: 'grumpy-veteran',
+    name: 'Grumpy Veteran',
+    description: 'Steady output but morale swings matter.',
+    modifiers: { efficiency: 0.05, comebackRate: -0.01, moraleSensitivity: 0.2, bevCapture: -0.02 },
+  },
+  {
+    id: 'hybrid-specialist',
+    name: 'Hybrid/EV Specialist',
+    description: 'Captures BEV service revenue.',
+    modifiers: { efficiency: 0.1, comebackRate: -0.02, moraleSensitivity: 0, bevCapture: 0.2 },
+  },
+  {
+    id: 'warranty-wizard',
+    name: 'Warranty Wizard',
+    description: 'Finds billable warranty work.',
+    modifiers: { efficiency: 0.08, comebackRate: -0.01, moraleSensitivity: 0.04, bevCapture: 0.02 },
+  },
+  {
+    id: 'detail-oriented',
+    name: 'Detail Oriented',
+    description: 'Very low comebacks but slower throughput.',
+    modifiers: { efficiency: -0.05, comebackRate: -0.08, moraleSensitivity: 0.05, bevCapture: 0 },
+  },
+];
+
+export const CUSTOMER_ARCHETYPES: CustomerArchetype[] = [
+  {
+    id: 'tire-kicker',
+    name: 'Tire-Kicker',
+    description: 'Here to browse with low intent.',
+    modifiers: { closeBias: -0.2, grossBias: -0.1, csiBias: 0, bevAffinity: -0.05, priceSensitivity: 0.6, loyalty: -0.2 },
+  },
+  {
+    id: 'payment-buyer',
+    name: 'Payment Buyer',
+    description: 'Payment sensitive, slow to close.',
+    modifiers: { closeBias: -0.1, grossBias: -0.15, csiBias: 0, bevAffinity: 0, priceSensitivity: 0.9, loyalty: -0.05 },
+  },
+  {
+    id: 'luxury-shopper',
+    name: 'Luxury Shopper',
+    description: 'Demands high CSI, pays for experience.',
+    modifiers: { closeBias: 0.05, grossBias: 0.12, csiBias: 0.2, bevAffinity: 0.05, priceSensitivity: 0.3, loyalty: 0.1 },
+  },
+  {
+    id: 'internet-shopper',
+    name: 'Internet Shopper',
+    description: 'Research heavy, expects best price.',
+    modifiers: { closeBias: -0.02, grossBias: -0.12, csiBias: -0.05, bevAffinity: 0.08, priceSensitivity: 0.8, loyalty: 0 },
+  },
+  {
+    id: 'loyalist',
+    name: 'Loyalist',
+    description: 'Repeat customer, easier close.',
+    modifiers: { closeBias: 0.2, grossBias: 0.08, csiBias: 0.1, bevAffinity: 0.05, priceSensitivity: 0.2, loyalty: 0.4 },
+  },
+  {
+    id: 'grinder',
+    name: 'Grinder',
+    description: 'Pushes for discounts, tough gross.',
+    modifiers: { closeBias: -0.03, grossBias: -0.2, csiBias: -0.05, bevAffinity: 0, priceSensitivity: 0.85, loyalty: -0.1 },
+  },
+  {
+    id: 'urgent-buyer',
+    name: 'Urgent Buyer',
+    description: 'Needs a car now, high close rate.',
+    modifiers: { closeBias: 0.3, grossBias: -0.05, csiBias: -0.02, bevAffinity: -0.02, priceSensitivity: 0.4, loyalty: -0.05 },
+  },
+  {
+    id: 'fleet-buyer',
+    name: 'Fleet Buyer',
+    description: 'Buys in bulk with thin margins.',
+    modifiers: { closeBias: 0.1, grossBias: -0.25, csiBias: 0.05, bevAffinity: 0.1, priceSensitivity: 0.7, loyalty: 0.2 },
+  },
+  {
+    id: 'ev-curious',
+    name: 'EV Curious',
+    description: 'Interested in BEVs and incentives.',
+    modifiers: { closeBias: 0.08, grossBias: -0.05, csiBias: 0.05, bevAffinity: 0.25, priceSensitivity: 0.5, loyalty: 0.05 },
+  },
+  {
+    id: 'service-to-sales',
+    name: 'Service-to-Sales',
+    description: 'In the shop, ready to trade.',
+    modifiers: { closeBias: 0.18, grossBias: 0, csiBias: 0.12, bevAffinity: 0.05, priceSensitivity: 0.35, loyalty: 0.3 },
+  },
+];

--- a/dealership-sim/backend/src/core/balance/coefficients.ts
+++ b/dealership-sim/backend/src/core/balance/coefficients.ts
@@ -1,0 +1,51 @@
+import { Coefficients, DEFAULT_COEFFICIENTS, HealthCheckResult, Vehicle } from '@dealership/shared';
+
+export const cloneCoefficients = (coefficients: Coefficients): Coefficients => ({
+  lead: { ...coefficients.lead },
+  sales: { ...coefficients.sales },
+  pricing: { ...coefficients.pricing },
+  inventory: { ...coefficients.inventory },
+  economy: { ...coefficients.economy },
+  service: { ...coefficients.service },
+  finance: { ...coefficients.finance },
+  morale: { ...coefficients.morale },
+  guardrails: { ...coefficients.guardrails },
+});
+
+export const mergeCoefficients = (base: Coefficients, patch: Partial<Coefficients>): Coefficients => {
+  const next = cloneCoefficients(base);
+  (Object.keys(patch) as (keyof Coefficients)[]).forEach((key) => {
+    const value = patch[key];
+    if (value) {
+      Object.assign((next as any)[key], value);
+    }
+  });
+  return next;
+};
+
+export const calculateExpectedGross = (inventory: Vehicle[], coefficients: Coefficients): number => {
+  if (inventory.length === 0) {
+    return coefficients.guardrails.targetReplacementGross;
+  }
+  const avgDesirability = inventory.reduce((acc, vehicle) => acc + vehicle.desirability, 0) / inventory.length;
+  const desirabilityFactor = 0.5 + avgDesirability / 200;
+  const expectedFront = (coefficients.pricing.holdbackPct * 40000 + 1800) * desirabilityFactor;
+  const expectedBack = coefficients.finance.avgBackGross * coefficients.finance.backGrossProb;
+  return expectedFront + expectedBack;
+};
+
+export const healthCheck = (inventory: Vehicle[], coefficients: Coefficients): HealthCheckResult => {
+  const expectedGross = calculateExpectedGross(inventory, coefficients);
+  const replacementGross = coefficients.guardrails.targetReplacementGross * (1 + coefficients.inventory.auctionCostSpread / 2);
+  const starving = expectedGross < replacementGross;
+  return {
+    starving,
+    expectedGross,
+    replacementGross,
+    message: starving
+      ? 'Current balance may not support replenishing inventory. Consider easing guardrails or boosting demand.'
+      : 'Coefficients support sustainable restocking.',
+  };
+};
+
+export const DEFAULT_SERVER_COEFFICIENTS = cloneCoefficients(DEFAULT_COEFFICIENTS);

--- a/dealership-sim/backend/src/core/engine/loop.ts
+++ b/dealership-sim/backend/src/core/engine/loop.ts
@@ -1,0 +1,237 @@
+import { Coefficients, DailyReport, GameState, MonthlyReport, PipelineState } from '@dealership/shared';
+import { GameRepository } from '../repository/gameRepository';
+import { RNG } from '../../utils/random';
+import { ageInventory, autoRestock } from '../services/inventory';
+import { simulateSalesDay } from '../services/sales';
+import { runServiceDepartment } from '../services/service';
+import { applyRandomEvents } from '../events/randomEvents';
+import { healthCheck } from '../balance/coefficients';
+import { clamp } from '../../utils/math';
+
+const DAYS_PER_MONTH = 30;
+
+export interface EngineOptions {
+  seed?: number;
+}
+
+export class SimulationEngine {
+  private rng: RNG;
+
+  constructor(private repository: GameRepository, private options: EngineOptions = {}) {
+    this.rng = new RNG(options.seed);
+  }
+
+  getState(): GameState {
+    return this.repository.getState();
+  }
+
+  tick(days = 1): GameState {
+    let state = this.repository.getState();
+    for (let i = 0; i < days; i += 1) {
+      state = this.runDay(state);
+    }
+    this.repository.setState(state);
+    return state;
+  }
+
+  updateCoefficients(coefficients: Coefficients): void {
+    const state = this.repository.getState();
+    state.coefficients = coefficients;
+    this.repository.setState(state);
+  }
+
+  private runDay(state: GameState): GameState {
+    if (state.paused) {
+      return state;
+    }
+
+    const nextState: GameState = {
+      ...state,
+      day: state.day + 1,
+      notifications: [],
+    };
+
+    if (nextState.day > DAYS_PER_MONTH) {
+      nextState.day = 1;
+      nextState.month += 1;
+      if (nextState.month > 12) {
+        nextState.month = 1;
+        nextState.year += 1;
+      }
+    }
+
+    // economy drift and random events
+    const drift = (this.rng.nextFloat() - 0.5) * state.coefficients.economy.volatility;
+    nextState.economy = {
+      ...nextState.economy,
+      demandIndex: clamp(nextState.economy.demandIndex + drift, 0.4, 2),
+      interestRate: clamp(
+        nextState.economy.interestRate + (this.rng.nextFloat() - 0.5) * state.coefficients.economy.interestRateBand,
+        1.5,
+        12,
+      ),
+      incentiveLevel: clamp(nextState.economy.incentiveLevel * (0.96 + this.rng.nextFloat() * 0.08), 0, 1.5),
+    };
+
+    const randomEvent = applyRandomEvents(nextState, this.rng);
+    nextState.economy = randomEvent.economy;
+    nextState.notifications = [...nextState.notifications, ...randomEvent.notifications];
+
+    // age inventory
+    const agedInventory = ageInventory(nextState.inventory, nextState.economy.demandIndex);
+
+    // run sales
+    const sales = simulateSalesDay(
+      nextState.advisors,
+      agedInventory.filter((vehicle) => vehicle.status === 'inStock'),
+      nextState.marketing,
+      nextState.economy,
+      nextState.coefficients,
+      this.rng,
+    );
+
+    // update inventory statuses
+    const soldIds = new Set(sales.soldVehicles.map((vehicle) => vehicle.id));
+    nextState.inventory = agedInventory
+      .filter((vehicle) => !soldIds.has(vehicle.id))
+      .concat(sales.soldVehicles.map((vehicle) => ({ ...vehicle, status: 'sold' as const })));
+
+    // update advisors morale
+    nextState.advisors = nextState.advisors.map((advisor) => {
+      const moraleAdjustment = sales.moraleDelta / Math.max(nextState.advisors.length, 1);
+      const trainingBoost = advisor.trained.length * (state.coefficients.morale.trainingEffect / 100);
+      const morale = clamp(advisor.morale + moraleAdjustment * 5 + trainingBoost, 20, 100);
+      return { ...advisor, morale };
+    });
+
+    const soldCount = sales.deals.length;
+    const trailingSales = Math.max(1, soldCount);
+
+    // service demand derived from sold units and base demand
+    const serviceDemand = Math.round(
+      nextState.coefficients.service.baseDemand * 0.5 +
+        soldCount * 0.8 +
+        nextState.inventory.length * 0.05,
+    );
+
+    const serviceResult = runServiceDepartment(
+      nextState.technicians,
+      nextState.serviceQueue,
+      serviceDemand,
+      this.rng,
+    );
+
+    nextState.completedROs = [...serviceResult.completed, ...nextState.completedROs].slice(0, 50);
+    nextState.serviceQueue = serviceResult.queue;
+
+    const serviceRevenue = serviceResult.partsRevenue + serviceResult.laborHours * 150;
+    const serviceGross = serviceRevenue * 0.4;
+
+    // update marketing lead multiplier
+    nextState.marketing.leadMultiplier = sales.leadsGenerated / Math.max(1, nextState.coefficients.lead.basePerDay);
+
+    // update pipeline
+    const pipeline: PipelineState = {
+      leads: sales.leadsGenerated,
+      appointments: sales.appointments,
+      deals: sales.dealsWorked,
+    };
+    nextState.pipeline = pipeline;
+
+    const cashDelta = sales.cashDelta + serviceGross;
+    nextState.cash += cashDelta;
+
+    // auto restock if needed
+    const restock = autoRestock(
+      nextState.inventory.filter((vehicle) => vehicle.status === 'inStock'),
+      nextState.cash,
+      nextState.coefficients,
+      this.rng,
+      trailingSales,
+    );
+    if (restock.cashSpent > 0 && restock.newVehicles.length > 0) {
+      nextState.cash -= restock.cashSpent;
+      nextState.inventory = nextState.inventory.concat(restock.newVehicles);
+      nextState.notifications.push(`Auto-acquired ${restock.newVehicles.length} vehicles to maintain days supply.`);
+    }
+
+    // update CSI and morale index
+    nextState.csi = clamp(nextState.csi + (sales.csiDelta + serviceResult.csiDelta) / 50, 10, 100);
+    nextState.moraleIndex = clamp(
+      nextState.advisors.reduce((acc, advisor) => acc + advisor.morale, 0) / Math.max(nextState.advisors.length, 1),
+      0,
+      100,
+    );
+
+    // store deals
+    nextState.recentDeals = [...sales.deals, ...nextState.recentDeals].slice(0, 20);
+
+    // reporting
+    const dailyReport: DailyReport = {
+      date: new Date().toISOString().split('T')[0],
+      salesUnits: soldCount,
+      frontGross: sales.deals.reduce((acc, deal) => acc + deal.frontGross, 0),
+      backGross: sales.deals.reduce((acc, deal) => acc + deal.backGross, 0),
+      totalGross: sales.deals.reduce((acc, deal) => acc + deal.totalGross, 0) + serviceGross,
+      closingRate: pipeline.deals > 0 ? soldCount / pipeline.deals : 0,
+      serviceLaborHours: serviceResult.laborHours,
+      servicePartsRevenue: serviceResult.partsRevenue,
+      serviceComebackRate: serviceResult.comebackRate,
+      cash: nextState.cash,
+      marketingSpend: nextState.marketing.spendPerDay,
+      moraleIndex: nextState.moraleIndex,
+      csi: nextState.csi,
+    };
+
+    nextState.dailyHistory = [...nextState.dailyHistory, dailyReport].slice(-60);
+
+    if (nextState.day === DAYS_PER_MONTH) {
+      const monthKey = `${nextState.year}-${String(nextState.month).padStart(2, '0')}`;
+      const monthReports = nextState.dailyHistory.filter((report) => report.date.startsWith(monthKey));
+      const salesUnits = monthReports.reduce((acc, report) => acc + report.salesUnits, 0);
+      const frontGross = monthReports.reduce((acc, report) => acc + report.frontGross, 0);
+      const backGross = monthReports.reduce((acc, report) => acc + report.backGross, 0);
+      const totalGross = monthReports.reduce((acc, report) => acc + report.totalGross, 0);
+      const serviceLabor = monthReports.reduce((acc, report) => acc + report.serviceLaborHours, 0);
+      const partsRevenue = monthReports.reduce((acc, report) => acc + report.servicePartsRevenue, 0);
+      const comebackRate = monthReports.length
+        ? monthReports.reduce((acc, report) => acc + report.serviceComebackRate, 0) / monthReports.length
+        : 0;
+      const closingRate = monthReports.length
+        ? monthReports.reduce((acc, report) => acc + report.closingRate, 0) / monthReports.length
+        : 0;
+
+      const monthly: MonthlyReport = {
+        month: monthKey,
+        salesUnits,
+        frontGross,
+        backGross,
+        totalGross,
+        avgFrontGross: salesUnits ? frontGross / salesUnits : 0,
+        avgBackGross: salesUnits ? backGross / salesUnits : 0,
+        closingRate,
+        inventoryStart: state.inventory.length,
+        inventoryEnd: nextState.inventory.length,
+        aged60Plus: nextState.inventory.filter((vehicle) => vehicle.ageDays >= 60).length,
+        aged90Plus: nextState.inventory.filter((vehicle) => vehicle.ageDays >= 90).length,
+        serviceLaborHours: serviceLabor,
+        servicePartsRevenue: partsRevenue,
+        comebackRate,
+        cashDelta: nextState.cash - state.cash,
+        advertisingROI: sales.cashDelta > 0 ? sales.cashDelta / Math.max(nextState.marketing.spendPerDay, 1) : 0,
+        fixedCoverage: partsRevenue > 0 ? serviceGross / partsRevenue : 0,
+        moraleTrend: nextState.moraleIndex - state.moraleIndex,
+        trainingCompletions: nextState.advisors.reduce((acc, advisor) => acc + advisor.trained.length, 0),
+        csi: nextState.csi,
+      };
+      nextState.monthlyReports = [monthly, ...nextState.monthlyReports.filter((report) => report.month !== monthKey)];
+    }
+
+    const guardrail = healthCheck(nextState.inventory, nextState.coefficients);
+    if (guardrail.starving) {
+      nextState.notifications.push(guardrail.message);
+    }
+
+    return nextState;
+  }
+}

--- a/dealership-sim/backend/src/core/events/randomEvents.ts
+++ b/dealership-sim/backend/src/core/events/randomEvents.ts
@@ -1,0 +1,34 @@
+import { EconomyState, GameState } from '@dealership/shared';
+import { RNG } from '../../utils/random';
+
+export interface RandomEventResult {
+  notifications: string[];
+  economy: EconomyState;
+}
+
+export const applyRandomEvents = (state: GameState, rng: RNG): RandomEventResult => {
+  const notifications: string[] = [];
+  const economy = { ...state.economy };
+
+  const roll = rng.nextFloat();
+  if (roll < 0.05) {
+    economy.incentiveLevel += 0.1;
+    economy.demandIndex += 0.08;
+    notifications.push('Factory incentive increased! Demand up 8%.');
+  } else if (roll < 0.1) {
+    economy.weatherFactor -= 0.15;
+    notifications.push('Stormy weather hurts showroom traffic.');
+  } else if (roll < 0.14) {
+    economy.demandIndex += 0.12;
+    notifications.push('Corporate fleet deal boosts lead flow!');
+  } else if (roll < 0.18) {
+    economy.interestRate += 0.2;
+    notifications.push('Bank tightens lending. F&I harder this week.');
+  }
+
+  economy.demandIndex = Math.max(0.4, Math.min(2, economy.demandIndex));
+  economy.weatherFactor = Math.max(0, Math.min(1, economy.weatherFactor));
+  economy.incentiveLevel = Math.max(0, Math.min(1.5, economy.incentiveLevel));
+
+  return { notifications, economy };
+};

--- a/dealership-sim/backend/src/core/repository/gameRepository.ts
+++ b/dealership-sim/backend/src/core/repository/gameRepository.ts
@@ -1,0 +1,22 @@
+import { GameState } from '@dealership/shared';
+
+export class GameRepository {
+  private state: GameState;
+
+  constructor(initialState: GameState) {
+    this.state = initialState;
+  }
+
+  getState(): GameState {
+    return this.state;
+  }
+
+  setState(state: GameState): void {
+    this.state = state;
+  }
+
+  updateState(mutator: (state: GameState) => GameState): GameState {
+    this.state = mutator(this.state);
+    return this.state;
+  }
+}

--- a/dealership-sim/backend/src/core/services/inventory.ts
+++ b/dealership-sim/backend/src/core/services/inventory.ts
@@ -1,0 +1,156 @@
+import { v4 as uuid } from 'uuid';
+import { Coefficients, Vehicle } from '@dealership/shared';
+import { RNG } from '../../utils/random';
+import { clamp } from '../../utils/math';
+
+const SEGMENT_BASE_DEMAND: Record<Vehicle['segment'], number> = {
+  luxury: 0.9,
+  performance: 0.8,
+  suv: 1.1,
+  sedan: 0.95,
+  compact: 1,
+  ev: 1.05,
+  crossover: 1.1,
+  convertible: 0.7,
+};
+
+const CONDITION_DESIRABILITY: Record<Vehicle['condition'], number> = {
+  new: 1,
+  used: 0.85,
+  cpo: 0.95,
+  bev: 1.1,
+};
+
+const AGE_DEPRECIATION = [
+  { max: 30, rate: 0.001 },
+  { max: 60, rate: 0.0025 },
+  { max: 120, rate: 0.004 },
+  { max: Infinity, rate: 0.006 },
+];
+
+export interface AcquirePackResult {
+  vehicles: Vehicle[];
+  cost: number;
+}
+
+export const ageInventory = (inventory: Vehicle[], economyDemand: number): Vehicle[] => {
+  return inventory.map((vehicle) => {
+    const ageDays = vehicle.ageDays + 1;
+    const bucket = AGE_DEPRECIATION.find((entry) => ageDays <= entry.max) ?? AGE_DEPRECIATION[AGE_DEPRECIATION.length - 1];
+    const desirabilityFactor = (vehicle.desirability / 100) * economyDemand;
+    const depreciation = vehicle.asking * bucket.rate * (1.2 - desirabilityFactor / 2);
+    return {
+      ...vehicle,
+      ageDays,
+      asking: Math.max(vehicle.floor, vehicle.asking - depreciation),
+      desirability: clamp(vehicle.desirability - bucket.rate * 100 * (1.1 - desirabilityFactor), 10, 100),
+    };
+  });
+};
+
+export const calculateDesirability = (vehicle: Vehicle, economySeason: string, demandIndex: number): number => {
+  const base = 60;
+  const segmentDemand = SEGMENT_BASE_DEMAND[vehicle.segment];
+  const seasonBonus =
+    economySeason === 'winter' && vehicle.segment === 'suv'
+      ? 10
+      : economySeason === 'summer' && vehicle.segment === 'convertible'
+      ? 12
+      : 0;
+  const conditionBonus = 20 * CONDITION_DESIRABILITY[vehicle.condition];
+  return clamp(base + segmentDemand * 15 + seasonBonus + conditionBonus + demandIndex * 10, 20, 100);
+};
+
+export const createVehicle = (
+  overrides: Partial<Vehicle>,
+  rng: RNG,
+  coefficients: Coefficients,
+  baseCost: number,
+): Vehicle => {
+  const holdbackPct = coefficients.pricing.holdbackPct;
+  const pack = coefficients.pricing.pack;
+  const recon = Math.max(200, coefficients.pricing.reconMean * (0.8 + rng.nextFloat() * 0.4));
+  const asking = baseCost * (1.18 + rng.nextFloat() * 0.08);
+  return {
+    id: uuid(),
+    stockNumber: `STK-${Math.floor(rng.nextFloat() * 90000 + 10000)}`,
+    year: overrides.year ?? 2024,
+    make: overrides.make ?? 'Bimmer',
+    model: overrides.model ?? 'Series',
+    segment: overrides.segment ?? 'sedan',
+    cost: baseCost,
+    floor: baseCost * 1.02,
+    asking,
+    ageDays: overrides.ageDays ?? 0,
+    desirability: overrides.desirability ?? clamp(55 + rng.nextFloat() * 30, 30, 100),
+    condition: overrides.condition ?? 'new',
+    reconCost: recon,
+    holdbackPct: holdbackPct,
+    pack,
+    status: overrides.status ?? 'inStock',
+  } as Vehicle;
+};
+
+export const acquirePack = (
+  type: 'desirable' | 'neutral' | 'undesirable',
+  qty: number,
+  rng: RNG,
+  coefficients: Coefficients,
+): AcquirePackResult => {
+  const vehicles: Vehicle[] = [];
+  let totalCost = 0;
+  for (let i = 0; i < qty; i += 1) {
+    const baseCostMultiplier =
+      type === 'desirable' ? 1.12 : type === 'neutral' ? 1 : type === 'undesirable' ? 0.88 : 1;
+    const baseCost = 28000 * baseCostMultiplier * (0.9 + rng.nextFloat() * 0.3);
+    const segmentPool: Vehicle['segment'][] = type === 'desirable' ? ['suv', 'ev', 'crossover'] : type === 'undesirable' ? ['sedan', 'compact'] : ['sedan', 'crossover', 'suv'];
+    const condition: Vehicle['condition'] = type === 'desirable' ? 'bev' : type === 'undesirable' ? 'used' : 'cpo';
+    const vehicle = createVehicle(
+      {
+        segment: rng.pick(segmentPool),
+        condition,
+        desirability:
+          type === 'desirable'
+            ? 80 + rng.nextFloat() * 20
+            : type === 'neutral'
+            ? 55 + rng.nextFloat() * 25
+            : 40 + rng.nextFloat() * 20,
+      },
+      rng,
+      coefficients,
+      baseCost,
+    );
+    totalCost += baseCost + vehicle.reconCost + vehicle.pack;
+    vehicles.push(vehicle);
+  }
+  return { vehicles, cost: totalCost };
+};
+
+export const estimateDaysSupply = (inventory: Vehicle[], trailingSales: number): number => {
+  if (trailingSales === 0) {
+    return inventory.length * 10;
+  }
+  return (inventory.length / trailingSales) * 30;
+};
+
+export const autoRestock = (
+  inventory: Vehicle[],
+  cash: number,
+  coefficients: Coefficients,
+  rng: RNG,
+  trailingSales: number,
+): { newVehicles: Vehicle[]; cashSpent: number } => {
+  const daysSupply = estimateDaysSupply(inventory, Math.max(1, trailingSales));
+  if (daysSupply >= coefficients.inventory.minDaysSupply) {
+    return { newVehicles: [], cashSpent: 0 };
+  }
+  const units = coefficients.inventory.bulkBuyUnits;
+  const pack = acquirePack('neutral', units, rng, coefficients);
+  const costPerUnit = pack.cost / units;
+  const affordableUnits = Math.min(units, Math.floor(cash / costPerUnit));
+  if (affordableUnits <= 0) {
+    return { newVehicles: [], cashSpent: 0 };
+  }
+  const selected = acquirePack('neutral', affordableUnits, rng, coefficients);
+  return { newVehicles: selected.vehicles, cashSpent: selected.cost };
+};

--- a/dealership-sim/backend/src/core/services/sales.ts
+++ b/dealership-sim/backend/src/core/services/sales.ts
@@ -1,0 +1,223 @@
+import {
+  Coefficients,
+  Customer,
+  Deal,
+  EconomyState,
+  MarketingState,
+  SalesAdvisor,
+  Vehicle,
+} from '@dealership/shared';
+import { RNG } from '../../utils/random';
+import { diminishingReturns, clamp, sigmoid } from '../../utils/math';
+import { CUSTOMER_ARCHETYPES, ADVISOR_ARCHETYPES } from '../balance/archetypes';
+
+export interface SalesDayResult {
+  deals: Deal[];
+  soldVehicles: Vehicle[];
+  remainingInventory: Vehicle[];
+  leadsGenerated: number;
+  appointments: number;
+  dealsWorked: number;
+  cashDelta: number;
+  csiDelta: number;
+  moraleDelta: number;
+  customers: Customer[];
+}
+
+const BASE_COST_PER_LEAD = 8;
+
+const createCustomer = (rng: RNG): Customer => {
+  const archetype = rng.pick(CUSTOMER_ARCHETYPES);
+  return {
+    id: `cust-${Date.now()}-${rng.nextFloat()}`,
+    type: archetype.name,
+    channel: rng.pick(['walk-in', 'web', 'phone', 'referral'] as const),
+    priceSensitivity: clamp(0.3 + archetype.modifiers.priceSensitivity, 0, 1),
+    paymentFocus: clamp(0.3 + rng.nextFloat() * 0.4, 0, 1),
+    loyalty: clamp(0.2 + archetype.modifiers.loyalty, 0, 1),
+    closeBias: archetype.modifiers.closeBias,
+    grossBias: archetype.modifiers.grossBias,
+    csiBias: archetype.modifiers.csiBias,
+    bevAffinity: archetype.modifiers.bevAffinity,
+  };
+};
+
+const advisorArchetypeModifier = (advisor: SalesAdvisor): number => {
+  const found = ADVISOR_ARCHETYPES.find((arch) => arch.id === advisor.archetype);
+  return found ? found.modifiers.close : 0;
+};
+
+const advisorBackModifier = (advisor: SalesAdvisor): number => {
+  const found = ADVISOR_ARCHETYPES.find((arch) => arch.id === advisor.archetype);
+  return found ? found.modifiers.backGross : 0;
+};
+
+const advisorMoraleEffect = (advisor: SalesAdvisor): number => {
+  return (advisor.morale - 50) / 200;
+};
+
+export const computeLeadVolume = (
+  marketing: MarketingState,
+  economy: EconomyState,
+  coefficients: Coefficients,
+): number => {
+  const marketingBoost = 1 + coefficients.lead.marketingK * diminishingReturns(marketing.spendPerDay / BASE_COST_PER_LEAD, coefficients.lead.diminishingK);
+  const weatherPenalty = 0.6 + economy.weatherFactor * 0.4;
+  const incentivesBoost = 1 + economy.incentiveLevel * 0.4;
+  return coefficients.lead.basePerDay * economy.demandIndex * marketingBoost * weatherPenalty * incentivesBoost;
+};
+
+const pickAdvisor = (advisors: SalesAdvisor[], rng: RNG): SalesAdvisor | null => {
+  const active = advisors.filter((advisor) => advisor.active);
+  if (!active.length) {
+    return null;
+  }
+  return rng.pick(active);
+};
+
+const pickVehicle = (inventory: Vehicle[], customer: Customer): Vehicle | null => {
+  const bevPreference = customer.bevAffinity > 0.1;
+  const eligible = inventory.filter((vehicle) => vehicle.status === 'inStock' && (bevPreference ? vehicle.condition === 'bev' || vehicle.segment === 'ev' : true));
+  const sorted = eligible.sort((a, b) => b.desirability - a.desirability);
+  return sorted[0] ?? null;
+};
+
+const computeClosingProbability = (
+  advisor: SalesAdvisor,
+  customer: Customer,
+  vehicle: Vehicle,
+  economy: EconomyState,
+  coefficients: Coefficients,
+): number => {
+  const advisorClose = (advisor.skill.close - 50) / 50 + advisorArchetypeModifier(advisor);
+  const customerClose = customer.closeBias;
+  const desirabilityZ = (vehicle.desirability - 60) / 25;
+  const economyFactor = (economy.demandIndex - 1) * coefficients.sales.economyWeight;
+  const priceGap = (vehicle.asking - vehicle.cost) / Math.max(vehicle.cost, 1);
+  const priceFit = -priceGap * (0.5 + customer.priceSensitivity);
+  const morale = advisorMoraleEffect(advisor);
+  const raw =
+    coefficients.sales.baseClose +
+    coefficients.sales.archetypeWeight * (advisorClose + morale) +
+    coefficients.sales.desirabilityWeight * desirabilityZ +
+    coefficients.sales.priceGapWeight * priceFit +
+    customerClose +
+    economyFactor;
+  return clamp(sigmoid(raw), 0.05, 0.95);
+};
+
+const computeSoldPrice = (
+  vehicle: Vehicle,
+  coefficients: Coefficients,
+  rng: RNG,
+  customer: Customer,
+  economy: EconomyState,
+): number => {
+  const variance = (rng.nextFloat() * 2 - 1) * coefficients.pricing.variancePct;
+  const incentiveBias = economy.incentiveLevel * 1000;
+  const discount = customer.priceSensitivity * 700;
+  const sold = vehicle.asking * (1 + variance) + incentiveBias - discount;
+  return Math.max(vehicle.floor, sold);
+};
+
+const computeFrontGross = (vehicle: Vehicle, soldPrice: number, coefficients: Coefficients): number => {
+  const holdback = soldPrice * vehicle.holdbackPct;
+  const costBasis = vehicle.cost + vehicle.reconCost + vehicle.pack;
+  return soldPrice - costBasis + holdback;
+};
+
+const computeBackGross = (
+  advisor: SalesAdvisor,
+  coefficients: Coefficients,
+  rng: RNG,
+  economy: EconomyState,
+): number => {
+  const baseProb = coefficients.finance.backGrossProb + advisorBackModifier(advisor);
+  const interestPenalty = (economy.interestRate - 5) / 10;
+  const finalProb = clamp(baseProb - interestPenalty, 0.1, 0.9);
+  return rng.nextFloat() < finalProb
+    ? coefficients.finance.avgBackGross * (1 + (advisor.skill.gross - 50) / 100)
+    : 0;
+};
+
+export const simulateSalesDay = (
+  advisors: SalesAdvisor[],
+  inventory: Vehicle[],
+  marketing: MarketingState,
+  economy: EconomyState,
+  coefficients: Coefficients,
+  rng: RNG,
+): SalesDayResult => {
+  const leads = Math.round(computeLeadVolume(marketing, economy, coefficients));
+  const appointments = Math.round(leads * (0.45 + economy.demandIndex * 0.15));
+  const dealsWorked = Math.round(appointments * 0.6);
+
+  const deals: Deal[] = [];
+  const soldVehicles: Vehicle[] = [];
+  const remainingInventory = [...inventory];
+  const customers: Customer[] = [];
+  let cashDelta = -marketing.spendPerDay;
+  let csiDelta = 0;
+  let moraleDelta = 0;
+
+  for (let i = 0; i < dealsWorked; i += 1) {
+    const advisor = pickAdvisor(advisors, rng);
+    if (!advisor) {
+      break;
+    }
+    const customer = createCustomer(rng);
+    const vehicle = pickVehicle(remainingInventory, customer);
+    if (!vehicle) {
+      break;
+    }
+    customers.push(customer);
+    const closeProb = computeClosingProbability(advisor, customer, vehicle, economy, coefficients);
+    if (rng.nextFloat() <= closeProb) {
+      const soldPrice = computeSoldPrice(vehicle, coefficients, rng, customer, economy);
+      const frontGross = computeFrontGross(vehicle, soldPrice, coefficients);
+      const backGross = computeBackGross(advisor, coefficients, rng, economy);
+      const totalGross = frontGross + backGross;
+      const deal: Deal = {
+        id: `deal-${Date.now()}-${i}`,
+        vehicleId: vehicle.id,
+        advisorId: advisor.id,
+        customerId: customer.id,
+        date: new Date().toISOString(),
+        frontGross,
+        backGross,
+        totalGross,
+        csiImpact: Math.max(-5, 5 * (advisor.skill.csi / 50 + customer.csiBias)),
+        soldPrice,
+      };
+      deals.push(deal);
+      soldVehicles.push({ ...vehicle, status: 'sold' });
+      const index = remainingInventory.findIndex((item) => item.id === vehicle.id);
+      if (index >= 0) {
+        remainingInventory.splice(index, 1);
+      }
+      cashDelta += soldPrice - (vehicle.cost + vehicle.reconCost + vehicle.pack);
+      csiDelta += deal.csiImpact;
+      moraleDelta += advisor.morale > 60 ? 0.2 : 0.1;
+    } else {
+      moraleDelta -= 0.05;
+    }
+  }
+
+  return {
+    deals,
+    soldVehicles,
+    remainingInventory,
+    leadsGenerated: leads,
+    appointments,
+    dealsWorked,
+    cashDelta,
+    csiDelta,
+    moraleDelta,
+    customers,
+  };
+};
+
+export const __testing = {
+  computeClosingProbability,
+  computeSoldPrice,
+};

--- a/dealership-sim/backend/src/core/services/service.ts
+++ b/dealership-sim/backend/src/core/services/service.ts
@@ -1,0 +1,83 @@
+import { RepairOrder, ServiceQueueItem, Technician } from '@dealership/shared';
+import { RNG } from '../../utils/random';
+import { clamp } from '../../utils/math';
+
+export interface ServiceResult {
+  completed: RepairOrder[];
+  queue: ServiceQueueItem[];
+  csiDelta: number;
+  laborHours: number;
+  partsRevenue: number;
+  comebackRate: number;
+}
+
+export const runServiceDepartment = (
+  technicians: Technician[],
+  queue: ServiceQueueItem[],
+  demand: number,
+  rng: RNG,
+): ServiceResult => {
+  const activeTechs = technicians.filter((tech) => tech.active);
+  const nextQueue: ServiceQueueItem[] = [...queue];
+  const completed: RepairOrder[] = [];
+  let csiDelta = 0;
+  let laborHours = 0;
+  let partsRevenue = 0;
+  let comebacks = 0;
+  let totalJobs = 0;
+
+  // generate new demand
+  while (nextQueue.length < demand) {
+    nextQueue.push({
+      id: `queue-${Date.now()}-${rng.nextFloat()}`,
+      status: 'waiting',
+      laborHours: clamp(1.5 + rng.nextFloat() * 2.5, 1, 5),
+      partsRevenue: 0,
+      comebackRisk: 0.1 + rng.nextFloat() * 0.15,
+    });
+  }
+
+  activeTechs.forEach((tech) => {
+    const moraleFactor = 1 + (tech.morale - 50) / 200;
+    const efficiency = clamp(tech.efficiency * moraleFactor, 0.4, 2);
+    let capacity = clamp(7 * efficiency, 3, 12);
+
+    for (let i = 0; i < nextQueue.length && capacity > 0; i += 1) {
+      const job = nextQueue[i];
+      if (job.status === 'complete') {
+        continue;
+      }
+      const hours = Math.min(job.laborHours, capacity);
+      capacity -= hours;
+      job.status = 'complete';
+      job.techId = tech.id;
+      job.completedOn = new Date().toISOString();
+      const parts = hours * 120 * (0.6 + rng.nextFloat() * 0.8);
+      job.partsRevenue = parts;
+      const comebackChance = clamp(job.comebackRisk + tech.comebackRate - moraleFactor * 0.05, 0.02, 0.25);
+      const comeback = rng.nextFloat() < comebackChance;
+      const csiImpact = comeback ? -5 : 3 * efficiency;
+      completed.push({
+        id: job.id,
+        techId: tech.id,
+        date: job.completedOn,
+        laborHours: hours,
+        partsRevenue: parts,
+        comeback,
+        csiImpact,
+      });
+      csiDelta += csiImpact;
+      laborHours += hours;
+      partsRevenue += parts;
+      if (comeback) {
+        comebacks += 1;
+      }
+      totalJobs += 1;
+    }
+  });
+
+  const remaining = nextQueue.filter((job) => job.status !== 'complete');
+  const comebackRate = totalJobs > 0 ? comebacks / totalJobs : 0;
+
+  return { completed, queue: remaining, csiDelta, laborHours, partsRevenue, comebackRate };
+};

--- a/dealership-sim/backend/src/data/seed.ts
+++ b/dealership-sim/backend/src/data/seed.ts
@@ -1,0 +1,170 @@
+import {
+  Coefficients,
+  DailyReport,
+  DEFAULT_COEFFICIENTS,
+  GameState,
+  MarketingState,
+  MonthlyReport,
+  SalesAdvisor,
+  Technician,
+  Vehicle,
+} from '@dealership/shared';
+import { ADVISOR_ARCHETYPES, TECH_ARCHETYPES } from '../core/balance/archetypes';
+import { RNG } from '../utils/random';
+import { createVehicle } from '../core/services/inventory';
+
+const STARTING_CASH = 2_000_000;
+const START_YEAR = 2024;
+const START_MONTH = 1;
+const START_DAY = 1;
+
+const baseMarketing: MarketingState = {
+  spendPerDay: 2500,
+  leadMultiplier: 1,
+};
+
+const createAdvisors = (rng: RNG): SalesAdvisor[] => {
+  return ADVISOR_ARCHETYPES.slice(0, 10).map((arch, index) => ({
+    id: `advisor-${index + 1}`,
+    name: arch.name,
+    archetype: arch.id,
+    skill: {
+      close: 55 + rng.nextFloat() * 30,
+      gross: 55 + rng.nextFloat() * 30,
+      csi: 50 + rng.nextFloat() * 20,
+      speed: 50 + rng.nextFloat() * 20,
+    },
+    morale: 65 + rng.nextFloat() * 20,
+    trained: index % 3 === 0 ? ['delivery-mastery'] : [],
+    active: true,
+  }));
+};
+
+const createTechnicians = (rng: RNG): Technician[] => {
+  return TECH_ARCHETYPES.slice(0, 8).map((arch, index) => ({
+    id: `tech-${index + 1}`,
+    name: arch.name,
+    archetype: arch.id,
+    efficiency: 1 + arch.modifiers.efficiency,
+    comebackRate: 0.08 + arch.modifiers.comebackRate,
+    morale: 60 + rng.nextFloat() * 25,
+    active: true,
+  }));
+};
+
+const createInventory = (rng: RNG, coefficients: Coefficients): Vehicle[] => {
+  const segments: Vehicle['segment'][] = ['suv', 'sedan', 'crossover', 'compact', 'ev', 'performance', 'luxury', 'convertible'];
+  const vehicles: Vehicle[] = [];
+  while (vehicles.length < 40) {
+    const baseCost = 28000 * (0.9 + rng.nextFloat() * 0.6);
+    const segment = rng.pick(segments);
+    const condition: Vehicle['condition'] = rng.pick(['new', 'used', 'cpo', 'bev']);
+    const vehicle = createVehicle(
+      {
+        segment,
+        condition,
+        desirability: 45 + rng.nextFloat() * 45,
+        ageDays: Math.floor(rng.nextFloat() * 40),
+        make: segment === 'ev' ? 'MIN-E' : 'Bimmer',
+        model: segment === 'suv' ? 'X7' : segment === 'performance' ? 'M4' : 'Series',
+      },
+      rng,
+      coefficients,
+      baseCost,
+    );
+    vehicles.push(vehicle);
+  }
+  return vehicles;
+};
+
+const createHistory = (rng: RNG): { daily: DailyReport[]; monthly: MonthlyReport[] } => {
+  const daily: DailyReport[] = [];
+  const monthly: MonthlyReport[] = [];
+  let cash = STARTING_CASH;
+  for (let i = 0; i < 30; i += 1) {
+    const units = Math.round(4 + rng.nextFloat() * 4);
+    const front = units * (2300 + rng.nextFloat() * 700);
+    const back = units * (900 + rng.nextFloat() * 300);
+    const total = front + back + 12000;
+    cash += front + back;
+    daily.push({
+      date: `2023-12-${String(i + 1).padStart(2, '0')}`,
+      salesUnits: units,
+      frontGross: front,
+      backGross: back,
+      totalGross: total,
+      closingRate: 0.4 + rng.nextFloat() * 0.1,
+      serviceLaborHours: 90 + rng.nextFloat() * 20,
+      servicePartsRevenue: 15000 + rng.nextFloat() * 4000,
+      serviceComebackRate: 0.08 + rng.nextFloat() * 0.04,
+      cash,
+      marketingSpend: baseMarketing.spendPerDay,
+      moraleIndex: 70,
+      csi: 82,
+    });
+  }
+  monthly.push({
+    month: '2023-12',
+    salesUnits: daily.reduce((acc, report) => acc + report.salesUnits, 0),
+    frontGross: daily.reduce((acc, report) => acc + report.frontGross, 0),
+    backGross: daily.reduce((acc, report) => acc + report.backGross, 0),
+    totalGross: daily.reduce((acc, report) => acc + report.totalGross, 0),
+    avgFrontGross: 2600,
+    avgBackGross: 950,
+    closingRate: 0.42,
+    inventoryStart: 40,
+    inventoryEnd: 38,
+    aged60Plus: 4,
+    aged90Plus: 1,
+    serviceLaborHours: daily.reduce((acc, report) => acc + report.serviceLaborHours, 0),
+    servicePartsRevenue: daily.reduce((acc, report) => acc + report.servicePartsRevenue, 0),
+    comebackRate: daily.reduce((acc, report) => acc + report.serviceComebackRate, 0) / daily.length,
+    cashDelta: 120000,
+    advertisingROI: 3.2,
+    fixedCoverage: 0.85,
+    moraleTrend: 1.2,
+    trainingCompletions: 4,
+    csi: 82,
+  });
+  return { daily, monthly };
+};
+
+export const createSeedState = (seed = 42, coefficients: Coefficients = DEFAULT_COEFFICIENTS): GameState => {
+  const rng = new RNG(seed);
+  const advisors = createAdvisors(rng);
+  const technicians = createTechnicians(rng);
+  const inventory = createInventory(rng, coefficients);
+  const history = createHistory(rng);
+
+  const state: GameState = {
+    day: START_DAY,
+    month: START_MONTH,
+    year: START_YEAR,
+    speed: 1,
+    paused: false,
+    cash: STARTING_CASH,
+    inventory,
+    advisors,
+    technicians,
+    pipeline: { leads: 30, appointments: 18, deals: 10 },
+    activeDeals: [],
+    recentDeals: [],
+    serviceQueue: [],
+    completedROs: [],
+    marketing: { ...baseMarketing },
+    economy: {
+      demandIndex: 1,
+      interestRate: 5.2,
+      incentiveLevel: 0.3,
+      weatherFactor: 0.8,
+      season: 'winter',
+    },
+    coefficients: { ...coefficients },
+    csi: 82,
+    moraleIndex: 72,
+    dailyHistory: history.daily,
+    monthlyReports: history.monthly,
+    notifications: ['Welcome to Dealership Sim! Use the control panel to tune your store.'],
+  };
+  return state;
+};

--- a/dealership-sim/backend/src/index.ts
+++ b/dealership-sim/backend/src/index.ts
@@ -1,0 +1,12 @@
+import { config } from 'dotenv';
+config();
+
+import { startServer } from './server';
+
+const port = Number(process.env.PORT) || 4000;
+const seedMode = process.env.SEED_MODE || 'reset';
+
+startServer({ port, seedMode }).catch((error) => {
+  console.error('Failed to start server', error);
+  process.exit(1);
+});

--- a/dealership-sim/backend/src/routes/config.ts
+++ b/dealership-sim/backend/src/routes/config.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { EngineRequest } from './types';
+import { healthCheck, mergeCoefficients } from '../core/balance/coefficients';
+
+const configSchema = z.partial(
+  z.object({
+    lead: z.object({ basePerDay: z.number().min(5).max(80).optional(), marketingK: z.number().min(0).max(2).optional(), diminishingK: z.number().min(0).max(2).optional() }).partial(),
+    sales: z.object({ baseClose: z.number().min(-1).max(1).optional(), desirabilityWeight: z.number().min(-2).max(2).optional(), priceGapWeight: z.number().min(-2).max(2).optional(), archetypeWeight: z.number().min(-2).max(2).optional(), economyWeight: z.number().min(-2).max(2).optional() }).partial(),
+    pricing: z.object({ variancePct: z.number().min(0).max(0.2).optional(), holdbackPct: z.number().min(0).max(0.1).optional(), pack: z.number().min(0).max(2000).optional(), reconMean: z.number().min(0).max(5000).optional() }).partial(),
+    inventory: z.object({ minDaysSupply: z.number().min(10).max(120).optional(), bulkBuyUnits: z.number().min(1).max(25).optional(), auctionCostSpread: z.number().min(0).max(0.5).optional() }).partial(),
+    economy: z.object({ volatility: z.number().min(0).max(0.5).optional(), incentiveImpact: z.number().min(0).max(0.5).optional(), interestRateBand: z.number().min(0).max(1).optional() }).partial(),
+    service: z.object({ baseDemand: z.number().min(0).max(150).optional(), partsToLaborRatio: z.number().min(0).max(3).optional(), comebackPenalty: z.number().min(0).max(20).optional() }).partial(),
+    finance: z.object({ avgBackGross: z.number().min(0).max(5000).optional(), backGrossProb: z.number().min(0).max(1).optional(), cashLagDays: z.number().min(0).max(10).optional() }).partial(),
+    morale: z.object({ trainingEffect: z.number().min(0).max(20).optional(), lowMoralePenalty: z.number().min(0).max(1).optional() }).partial(),
+    guardrails: z.object({ targetReplacementGross: z.number().min(1000).max(8000).optional() }).partial(),
+  }),
+);
+
+const router = Router();
+
+router.get('/config', (req: EngineRequest, res) => {
+  const state = req.engine.getState();
+  const check = healthCheck(state.inventory, state.coefficients);
+  res.json({ coefficients: state.coefficients, health: check });
+});
+
+router.put('/config', (req: EngineRequest, res) => {
+  const parsed = configSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const state = req.engine.getState();
+  const merged = mergeCoefficients(state.coefficients, parsed.data);
+  req.engine.updateCoefficients(merged);
+  const check = healthCheck(state.inventory, merged);
+  res.json({ coefficients: merged, health: check });
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/control.ts
+++ b/dealership-sim/backend/src/routes/control.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { EngineRequest } from './types';
+
+const router = Router();
+
+router.post('/pause', (req: EngineRequest, res) => {
+  const paused = Boolean(req.body?.paused);
+  const state = req.engine.getState();
+  state.paused = paused;
+  req.repository.setState(state);
+  req.schedule();
+  res.json(state);
+});
+
+router.post('/speed', (req: EngineRequest, res) => {
+  const speed = [1, 5, 30].includes(req.body?.multiplier) ? req.body.multiplier : 1;
+  const state = req.engine.getState();
+  state.speed = speed;
+  req.repository.setState(state);
+  req.schedule();
+  res.json(state);
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/inventory.ts
+++ b/dealership-sim/backend/src/routes/inventory.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { EngineRequest } from './types';
+import { acquirePack } from '../core/services/inventory';
+import { RNG } from '../utils/random';
+
+const router = Router();
+
+const schema = z.object({
+  pack: z.enum(['desirable', 'neutral', 'undesirable']),
+  qty: z.number().min(1).max(20),
+});
+
+router.post('/inventory/acquire', (req: EngineRequest, res) => {
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const state = req.engine.getState();
+  const rng = new RNG();
+  const acquisition = acquirePack(parsed.data.pack, parsed.data.qty, rng, state.coefficients);
+  if (acquisition.cost > state.cash) {
+    return res.status(400).json({ error: 'Not enough cash to acquire vehicles' });
+  }
+  state.cash -= acquisition.cost;
+  state.inventory = [...state.inventory, ...acquisition.vehicles];
+  state.notifications.push(`Acquired ${acquisition.vehicles.length} ${parsed.data.pack} vehicles.`);
+  req.repository.setState(state);
+  res.json(state);
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/marketing.ts
+++ b/dealership-sim/backend/src/routes/marketing.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { EngineRequest } from './types';
+
+const router = Router();
+
+const schema = z.object({
+  perDay: z.number().min(0).max(25000),
+});
+
+router.post('/marketing/spend', (req: EngineRequest, res) => {
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const state = req.engine.getState();
+  state.marketing.spendPerDay = parsed.data.perDay;
+  state.notifications.push(`Marketing spend updated to $${parsed.data.perDay.toFixed(0)} per day.`);
+  req.repository.setState(state);
+  res.json(state);
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/reports.ts
+++ b/dealership-sim/backend/src/routes/reports.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { EngineRequest } from './types';
+
+const router = Router();
+
+router.get('/reports/monthly', (req: EngineRequest, res) => {
+  const month = req.query.month as string | undefined;
+  const state = req.engine.getState();
+  if (month) {
+    const report = state.monthlyReports.find((item) => item.month === month);
+    if (!report) {
+      return res.status(404).json({ error: 'Report not found' });
+    }
+    return res.json(report);
+  }
+  res.json(state.monthlyReports);
+});
+
+router.get('/reports/export', (req: EngineRequest, res) => {
+  const state = req.engine.getState();
+  res.json({ month: `${state.year}-${String(state.month).padStart(2, '0')}`, daily: state.dailyHistory });
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/staff.ts
+++ b/dealership-sim/backend/src/routes/staff.ts
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { EngineRequest } from './types';
+import { ADVISOR_ARCHETYPES, TECH_ARCHETYPES } from '../core/balance/archetypes';
+
+const router = Router();
+
+const hireSchema = z.object({
+  role: z.enum(['advisor', 'tech']),
+  archetype: z.string(),
+});
+
+const trainSchema = z.object({
+  id: z.string(),
+  program: z.string(),
+});
+
+router.post('/staff/hire', (req: EngineRequest, res) => {
+  const parsed = hireSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const state = req.engine.getState();
+  if (parsed.data.role === 'advisor') {
+    const archetype = ADVISOR_ARCHETYPES.find((arch) => arch.id === parsed.data.archetype);
+    if (!archetype) {
+      return res.status(400).json({ error: 'Unknown advisor archetype' });
+    }
+    state.advisors.push({
+      id: `advisor-${Date.now()}`,
+      name: `${archetype.name} ${Math.floor(Math.random() * 90)}`,
+      archetype: archetype.id,
+      skill: {
+        close: 55 + Math.random() * 20,
+        gross: 55 + Math.random() * 20,
+        csi: 50 + Math.random() * 20,
+        speed: 50 + Math.random() * 20,
+      },
+      morale: 68,
+      trained: [],
+      active: true,
+    });
+  } else {
+    const archetype = TECH_ARCHETYPES.find((arch) => arch.id === parsed.data.archetype);
+    if (!archetype) {
+      return res.status(400).json({ error: 'Unknown technician archetype' });
+    }
+    state.technicians.push({
+      id: `tech-${Date.now()}`,
+      name: `${archetype.name} ${Math.floor(Math.random() * 90)}`,
+      archetype: archetype.id,
+      efficiency: 1 + archetype.modifiers.efficiency,
+      comebackRate: 0.08 + archetype.modifiers.comebackRate,
+      morale: 64,
+      active: true,
+    });
+  }
+  state.notifications.push(`Hired a new ${parsed.data.role} (${parsed.data.archetype}).`);
+  req.repository.setState(state);
+  res.json(state);
+});
+
+router.post('/staff/train', (req: EngineRequest, res) => {
+  const parsed = trainSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const state = req.engine.getState();
+  const advisor = state.advisors.find((a) => a.id === parsed.data.id);
+  if (advisor) {
+    advisor.trained = Array.from(new Set([...advisor.trained, parsed.data.program]));
+    advisor.morale = Math.min(100, advisor.morale + 5);
+    state.notifications.push(`${advisor.name} completed ${parsed.data.program}.`);
+  }
+  req.repository.setState(state);
+  res.json(state);
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/state.ts
+++ b/dealership-sim/backend/src/routes/state.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { EngineRequest } from './types';
+
+const router = Router();
+
+router.get('/state', (req: EngineRequest, res) => {
+  res.json(req.engine.getState());
+});
+
+router.post('/tick', (req: EngineRequest, res) => {
+  const days = typeof req.body?.days === 'number' ? req.body.days : 1;
+  const state = req.engine.tick(Math.max(1, Math.min(30, days)));
+  res.json(state);
+});
+
+export default router;

--- a/dealership-sim/backend/src/routes/types.ts
+++ b/dealership-sim/backend/src/routes/types.ts
@@ -1,0 +1,19 @@
+import { Request } from 'express';
+import { SimulationEngine } from '../core/engine/loop';
+import { GameRepository } from '../core/repository/gameRepository';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    engine?: SimulationEngine;
+    repository?: GameRepository;
+    schedule?: () => void;
+    savePath?: string | null;
+  }
+}
+
+export type EngineRequest = Request & {
+  engine: SimulationEngine;
+  repository: GameRepository;
+  schedule: () => void;
+  savePath?: string | null;
+};

--- a/dealership-sim/backend/src/server.ts
+++ b/dealership-sim/backend/src/server.ts
@@ -1,0 +1,100 @@
+import express from 'express';
+import cors from 'cors';
+import { GameRepository } from './core/repository/gameRepository';
+import { SimulationEngine } from './core/engine/loop';
+import { createSeedState } from './data/seed';
+import { loadStateFromFile, saveStateToFile } from './utils/save';
+import stateRoutes from './routes/state';
+import configRoutes from './routes/config';
+import controlRoutes from './routes/control';
+import staffRoutes from './routes/staff';
+import inventoryRoutes from './routes/inventory';
+import marketingRoutes from './routes/marketing';
+import reportsRoutes from './routes/reports';
+
+interface StartOptions {
+  port: number;
+  seedMode?: string;
+}
+
+export const startServer = async ({ port, seedMode }: StartOptions) => {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  const savePath = process.env.SAVE_PATH;
+  const shouldReset = seedMode === 'reset';
+  let initialState = shouldReset ? null : await loadStateFromFile(savePath ?? undefined);
+  if (!initialState) {
+    initialState = createSeedState();
+  }
+  const repository = new GameRepository(initialState);
+  const engine = new SimulationEngine(repository, { seed: 1337 });
+
+  let interval: NodeJS.Timer | null = null;
+  const baseTickInterval = Number(process.env.TICK_INTERVAL_MS) || 1000;
+
+  const schedule = () => {
+    if (interval) {
+      clearInterval(interval);
+    }
+    const state = engine.getState();
+    if (!state.paused) {
+      interval = setInterval(() => {
+        const updated = engine.tick(state.speed);
+        if (savePath) {
+          saveStateToFile(updated, savePath).catch((error) => console.error('Failed to save state', error));
+        }
+      }, Math.max(200, baseTickInterval / state.speed));
+    }
+  };
+
+  schedule();
+
+  app.use((req, res, next) => {
+    (req as any).engine = engine;
+    (req as any).repository = repository;
+    (req as any).schedule = schedule;
+    (req as any).savePath = savePath;
+    next();
+  });
+
+  app.use('/api', stateRoutes);
+  app.use('/api', configRoutes);
+  app.use('/api', controlRoutes);
+  app.use('/api', staffRoutes);
+  app.use('/api', inventoryRoutes);
+  app.use('/api', marketingRoutes);
+  app.use('/api', reportsRoutes);
+
+  app.post('/api/save', async (req, res) => {
+    const state = engine.getState();
+    try {
+      await saveStateToFile(state, savePath ?? undefined);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to save game' });
+    }
+  });
+
+  app.post('/api/load', async (req, res) => {
+    try {
+      const loaded = await loadStateFromFile(savePath ?? undefined);
+      if (!loaded) {
+        return res.status(404).json({ error: 'No save game found' });
+      }
+      repository.setState(loaded);
+      res.json(engine.getState());
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to load game' });
+    }
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.listen(port, () => {
+    console.log(`Backend listening on http://localhost:${port}`);
+  });
+};

--- a/dealership-sim/backend/src/utils/math.ts
+++ b/dealership-sim/backend/src/utils/math.ts
@@ -1,0 +1,14 @@
+export const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export const sigmoid = (x: number) => 1 / (1 + Math.exp(-x));
+
+export const diminishingReturns = (base: number, k: number) => Math.log(1 + k * base);
+
+export const weightedAverage = (values: number[], weights: number[]) => {
+  const totalWeight = weights.reduce((acc, weight) => acc + weight, 0);
+  if (totalWeight === 0) {
+    return 0;
+  }
+  const weightedSum = values.reduce((acc, value, idx) => acc + value * weights[idx], 0);
+  return weightedSum / totalWeight;
+};

--- a/dealership-sim/backend/src/utils/random.ts
+++ b/dealership-sim/backend/src/utils/random.ts
@@ -1,0 +1,26 @@
+export class RNG {
+  private seed: number;
+
+  constructor(seed: number = Date.now() % 2147483647) {
+    if (seed <= 0) {
+      seed += 2147483646;
+    }
+    this.seed = seed;
+  }
+
+  next(): number {
+    this.seed = (this.seed * 16807) % 2147483647;
+    return this.seed;
+  }
+
+  nextFloat(): number {
+    return (this.next() - 1) / 2147483646;
+  }
+
+  pick<T>(array: T[]): T {
+    const index = Math.floor(this.nextFloat() * array.length);
+    return array[Math.min(array.length - 1, Math.max(0, index))];
+  }
+}
+
+export const seededRng = (seed?: number) => new RNG(seed);

--- a/dealership-sim/backend/src/utils/save.ts
+++ b/dealership-sim/backend/src/utils/save.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { GameState } from '@dealership/shared';
+
+const DEFAULT_SAVE_PATH = path.resolve(__dirname, '../../data/save.json');
+
+export const loadStateFromFile = async (customPath?: string): Promise<GameState | null> => {
+  const filePath = customPath ? path.resolve(customPath) : DEFAULT_SAVE_PATH;
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as GameState;
+  } catch (error) {
+    return null;
+  }
+};
+
+export const saveStateToFile = async (state: GameState, customPath?: string): Promise<void> => {
+  const filePath = customPath ? path.resolve(customPath) : DEFAULT_SAVE_PATH;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(state, null, 2), 'utf-8');
+};

--- a/dealership-sim/backend/src/utils/time.ts
+++ b/dealership-sim/backend/src/utils/time.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs';
+
+export const formatDate = (day: number, month: number, year: number) => {
+  return dayjs().year(year).month(month - 1).date(day).format('YYYY-MM-DD');
+};
+
+export const formatMonth = (month: number, year: number) => {
+  return dayjs().year(year).month(month - 1).format('YYYY-MM');
+};

--- a/dealership-sim/backend/tsconfig.json
+++ b/dealership-sim/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/dealership-sim/frontend/index.html
+++ b/dealership-sim/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dealership Simulator</title>
+  </head>
+  <body class="bg-slate-950 text-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dealership-sim/frontend/package.json
+++ b/dealership-sim/frontend/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@dealership/frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css,json,md}'",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@dealership/shared": "workspace:*",
+    "axios": "1.6.7",
+    "clsx": "2.1.0",
+    "lucide-react": "0.294.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "2.10.3",
+    "zustand": "4.4.7",
+    "immer": "10.0.3",
+    "@radix-ui/react-tabs": "1.0.3",
+    "@radix-ui/react-switch": "1.0.3",
+    "@radix-ui/react-toast": "1.1.5"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "6.2.1",
+    "@testing-library/react": "14.1.2",
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.46",
+    "@types/react-dom": "18.2.18",
+    "@vitejs/plugin-react": "4.2.1",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-react": "7.33.2",
+    "postcss": "8.4.33",
+    "prettier": "3.1.1",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3",
+    "vite": "5.0.8",
+    "vitest": "0.34.6"
+  }
+}

--- a/dealership-sim/frontend/postcss.config.js
+++ b/dealership-sim/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dealership-sim/frontend/src/App.tsx
+++ b/dealership-sim/frontend/src/App.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo } from 'react';
+import { Loader2, Pause, Play, AlertTriangle } from 'lucide-react';
+import { useGameStore } from './state/useGameStore';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
+import { Button } from './components/ui/button';
+import { ToastProvider, ToastViewport, Toast, ToastTitle, ToastDescription } from './components/ui/toast';
+import Dashboard from './features/dashboard/Dashboard';
+import ControlPanel from './features/control-panel/ControlPanel';
+import InventoryView from './features/inventory/InventoryView';
+import SalesView from './features/sales/SalesView';
+import ServiceView from './features/service/ServiceView';
+import ReportsView from './features/reports/ReportsView';
+
+const App = () => {
+  const {
+    gameState,
+    initialize,
+    loading,
+    error,
+    tick,
+    setPaused,
+    setSpeed,
+    toasts,
+    dismissToast,
+    health,
+  } = useGameStore();
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  const kpis = useMemo(() => {
+    if (!gameState) return [];
+    const soldMTD = gameState.dailyHistory
+      .filter((report) => report.date.includes(`${gameState.year}-${String(gameState.month).padStart(2, '0')}`))
+      .reduce((acc, report) => acc + report.salesUnits, 0);
+    const grossMTD = gameState.dailyHistory
+      .filter((report) => report.date.includes(`${gameState.year}-${String(gameState.month).padStart(2, '0')}`))
+      .reduce((acc, report) => acc + report.totalGross, 0);
+    return [
+      { label: 'Cash', value: `$${gameState.cash.toLocaleString()}` },
+      { label: 'Units In Stock', value: gameState.inventory.filter((vehicle) => vehicle.status === 'inStock').length },
+      { label: 'Units Sold (MTD)', value: soldMTD },
+      { label: 'Gross (MTD)', value: `$${Math.round(grossMTD).toLocaleString()}` },
+      { label: 'Service Hours', value: Math.round(gameState.dailyHistory[gameState.dailyHistory.length - 1]?.serviceLaborHours ?? 0) },
+      { label: 'CSI', value: Math.round(gameState.csi) },
+    ];
+  }, [gameState]);
+
+  if (loading || !gameState) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-background text-foreground">
+        {error ? (
+          <div className="text-center">
+            <p className="text-xl font-semibold">{error}</p>
+            <Button className="mt-4" onClick={() => initialize()}>
+              Retry
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 text-lg">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            Preparing showroom...
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const isPaused = gameState.paused;
+
+  return (
+    <ToastProvider swipeDirection="right">
+      <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 pb-24 text-foreground">
+        <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+          <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">Dealership Simulator</h1>
+              <p className="text-sm text-slate-400">
+                Day {gameState.day} · {new Date().toLocaleDateString(undefined, { month: 'long' })} {gameState.year}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={() => tick(1)}>
+                Step Day
+              </Button>
+              <Button variant="outline" onClick={() => setSpeed(1)} className={gameState.speed === 1 ? 'border-primary text-primary' : ''}>
+                1x
+              </Button>
+              <Button variant="outline" onClick={() => setSpeed(5)} className={gameState.speed === 5 ? 'border-primary text-primary' : ''}>
+                5x
+              </Button>
+              <Button variant="outline" onClick={() => setSpeed(30)} className={gameState.speed === 30 ? 'border-primary text-primary' : ''}>
+                30x
+              </Button>
+              <Button variant="outline" onClick={() => setPaused(!isPaused)}>
+                {isPaused ? (
+                  <span className="flex items-center gap-2"><Play className="h-4 w-4" /> Resume</span>
+                ) : (
+                  <span className="flex items-center gap-2"><Pause className="h-4 w-4" /> Pause</span>
+                )}
+              </Button>
+            </div>
+          </div>
+          {health?.starving && (
+            <div className="border-t border-amber-500/30 bg-amber-500/10 py-2 text-center text-sm text-amber-200">
+              <AlertTriangle className="mr-2 inline h-4 w-4" /> {health.message}
+            </div>
+          )}
+        </header>
+
+        <main className="mx-auto max-w-7xl px-6 py-8">
+          <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-6">
+            {kpis.map((kpi) => (
+              <div key={kpi.label} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 shadow">
+                <p className="text-xs uppercase tracking-wide text-slate-400">{kpi.label}</p>
+                <p className="mt-2 text-xl font-semibold">{kpi.value}</p>
+              </div>
+            ))}
+          </section>
+
+          <Tabs defaultValue="dashboard" className="mt-8">
+            <TabsList>
+              <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+              <TabsTrigger value="control">Control Panel</TabsTrigger>
+              <TabsTrigger value="inventory">Inventory</TabsTrigger>
+              <TabsTrigger value="sales">Sales</TabsTrigger>
+              <TabsTrigger value="service">Service</TabsTrigger>
+              <TabsTrigger value="reports">Reports</TabsTrigger>
+            </TabsList>
+            <TabsContent value="dashboard">
+              <Dashboard state={gameState} />
+            </TabsContent>
+            <TabsContent value="control">
+              <ControlPanel state={gameState} health={health} />
+            </TabsContent>
+            <TabsContent value="inventory">
+              <InventoryView state={gameState} />
+            </TabsContent>
+            <TabsContent value="sales">
+              <SalesView state={gameState} />
+            </TabsContent>
+            <TabsContent value="service">
+              <ServiceView state={gameState} />
+            </TabsContent>
+            <TabsContent value="reports">
+              <ReportsView state={gameState} />
+            </TabsContent>
+          </Tabs>
+        </main>
+      </div>
+
+      <ToastViewport className="fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2" />
+      {toasts.map((toast) => (
+        <Toast key={toast.id} open onOpenChange={(open) => !open && dismissToast(toast.id)}>
+          <div className="flex flex-col">
+            <ToastTitle>{toast.title}</ToastTitle>
+            <ToastDescription>{toast.description}</ToastDescription>
+          </div>
+        </Toast>
+      ))}
+    </ToastProvider>
+  );
+};
+
+export default App;

--- a/dealership-sim/frontend/src/__tests__/Dashboard.test.tsx
+++ b/dealership-sim/frontend/src/__tests__/Dashboard.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import Dashboard from '../features/dashboard/Dashboard';
+import { createSeedState } from '../../../backend/src/data/seed';
+
+describe('Dashboard', () => {
+  it('shows cash KPI', () => {
+    const state = createSeedState();
+    render(<Dashboard state={state} />);
+    expect(screen.getByText('Cash Balance')).toBeInTheDocument();
+  });
+});

--- a/dealership-sim/frontend/src/components/ui/badge.tsx
+++ b/dealership-sim/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,17 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+type BadgeProps = PropsWithChildren<{ variant?: 'default' | 'success' | 'warning' | 'danger'; className?: string }>;
+
+const variants: Record<NonNullable<BadgeProps['variant']>, string> = {
+  default: 'bg-slate-800 text-slate-100',
+  success: 'bg-emerald-600/80 text-emerald-50',
+  warning: 'bg-amber-500/80 text-amber-950',
+  danger: 'bg-rose-500/80 text-rose-50',
+};
+
+export const Badge = ({ variant = 'default', className, children }: BadgeProps) => (
+  <span className={clsx('inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold', variants[variant], className)}>
+    {children}
+  </span>
+);

--- a/dealership-sim/frontend/src/components/ui/button.tsx
+++ b/dealership-sim/frontend/src/components/ui/button.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { clsx } from 'clsx';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+  variant?: 'default' | 'outline' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+};
+
+const sizeStyles: Record<NonNullable<ButtonProps['size']>, string> = {
+  sm: 'px-2.5 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-3 text-base',
+};
+
+const variantStyles: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default: 'bg-primary text-primary-foreground hover:bg-blue-600',
+  outline: 'border border-slate-600 text-foreground hover:bg-slate-800',
+  ghost: 'hover:bg-slate-800 text-foreground',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, asChild, variant = 'default', size = 'md', ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={clsx(
+          'inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:pointer-events-none disabled:opacity-60',
+          sizeStyles[size],
+          variantStyles[variant],
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';

--- a/dealership-sim/frontend/src/components/ui/card.tsx
+++ b/dealership-sim/frontend/src/components/ui/card.tsx
@@ -1,0 +1,24 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+export const Card = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <div className={clsx('rounded-xl border border-slate-800 bg-slate-900/60 p-4 shadow-lg backdrop-blur', className)}>
+    {children}
+  </div>
+);
+
+export const CardHeader = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <div className={clsx('mb-3 flex items-center justify-between', className)}>{children}</div>
+);
+
+export const CardTitle = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <h3 className={clsx('text-lg font-semibold text-foreground', className)}>{children}</h3>
+);
+
+export const CardDescription = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <p className={clsx('text-sm text-slate-400', className)}>{children}</p>
+);
+
+export const CardContent = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <div className={clsx('space-y-3', className)}>{children}</div>
+);

--- a/dealership-sim/frontend/src/components/ui/switch.tsx
+++ b/dealership-sim/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,17 @@
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import { clsx } from 'clsx';
+
+export const Switch = (props: SwitchPrimitive.SwitchProps) => (
+  <SwitchPrimitive.Root
+    className={clsx(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-slate-700 transition-colors data-[state=checked]:bg-primary',
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={clsx(
+        'pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitive.Root>
+);

--- a/dealership-sim/frontend/src/components/ui/tabs.tsx
+++ b/dealership-sim/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,28 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { clsx } from 'clsx';
+
+export const Tabs = TabsPrimitive.Root;
+export const TabsList = ({ className, ...props }: TabsPrimitive.TabsListProps) => (
+  <TabsPrimitive.List
+    className={clsx(
+      'inline-flex items-center gap-1 rounded-full bg-slate-900/70 p-1 text-slate-300 shadow-inner',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export const TabsTrigger = ({ className, ...props }: TabsPrimitive.TabsTriggerProps) => (
+  <TabsPrimitive.Trigger
+    className={clsx(
+      'inline-flex min-w-[120px] items-center justify-center rounded-full px-4 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-primary data-[state=active]:text-primary-foreground',
+      'data-[state=inactive]:text-slate-400 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export const TabsContent = ({ className, ...props }: TabsPrimitive.TabsContentProps) => (
+  <TabsPrimitive.Content className={clsx('mt-6 focus-visible:outline-none', className)} {...props} />
+);

--- a/dealership-sim/frontend/src/components/ui/toast.tsx
+++ b/dealership-sim/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,26 @@
+import * as ToastPrimitive from '@radix-ui/react-toast';
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+export const ToastProvider = ToastPrimitive.Provider;
+export const ToastViewport = ToastPrimitive.Viewport;
+
+export const Toast = ({ className, ...props }: ToastPrimitive.ToastProps) => (
+  <ToastPrimitive.Root
+    className={clsx(
+      'pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-xl border border-slate-700 bg-slate-900/90 p-4 shadow-xl backdrop-blur',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export const ToastTitle = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <ToastPrimitive.Title className={clsx('text-sm font-semibold text-foreground', className)}>{children}</ToastPrimitive.Title>
+);
+
+export const ToastDescription = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <ToastPrimitive.Description className={clsx('text-sm text-slate-300', className)}>{children}</ToastPrimitive.Description>
+);
+
+export const ToastClose = ToastPrimitive.Close;

--- a/dealership-sim/frontend/src/features/control-panel/ControlPanel.tsx
+++ b/dealership-sim/frontend/src/features/control-panel/ControlPanel.tsx
@@ -1,0 +1,149 @@
+import { ChangeEvent } from 'react';
+import { GameState, HealthCheckResult, CONFIG_PRESETS } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import { useGameStore } from '../../state/useGameStore';
+
+interface Props {
+  state: GameState;
+  health: HealthCheckResult | null;
+}
+
+const ControlPanel = ({ state, health }: Props) => {
+  const { updateCoefficients, applyPreset, updateMarketing } = useGameStore();
+
+  const handleChange = (group: keyof GameState['coefficients'], key: string) => (event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    updateCoefficients({ [group]: { [key]: value } } as any);
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Presets</CardTitle>
+          <CardDescription>Select a balancing preset to quickly tune the store.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {CONFIG_PRESETS.map((preset) => (
+            <Button key={preset.id} variant="outline" onClick={() => applyPreset(preset.id)}>
+              {preset.name}
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Health Check</CardTitle>
+          <CardDescription>
+            {health?.starving
+              ? `Warning: Expected gross ${Math.round(health.expectedGross)} vs replacement ${Math.round(health.replacementGross)}`
+              : 'Current coefficients support sustainable inventory replacement.'}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Marketing & Lead Generation</CardTitle>
+          <CardDescription>Adjust spend and demand coefficients.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-4">
+          <label className="text-sm">
+            Spend / Day
+            <input
+              type="number"
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+              value={state.marketing.spendPerDay}
+              onChange={(event) => updateMarketing(Number(event.target.value))}
+            />
+          </label>
+          <label className="text-sm">
+            Base Per Day
+            <input
+              type="number"
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+              value={state.coefficients.lead.basePerDay}
+              onChange={handleChange('lead', 'basePerDay')}
+            />
+          </label>
+          <label className="text-sm">
+            Marketing K
+            <input
+              type="number"
+              step="0.01"
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+              value={state.coefficients.lead.marketingK}
+              onChange={handleChange('lead', 'marketingK')}
+            />
+          </label>
+          <label className="text-sm">
+            Diminishing K
+            <input
+              type="number"
+              step="0.01"
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+              value={state.coefficients.lead.diminishingK}
+              onChange={handleChange('lead', 'diminishingK')}
+            />
+          </label>
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Sales Tuning</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-3">
+          {Object.entries(state.coefficients.sales).map(([key, value]) => (
+            <label key={key} className="text-sm capitalize">
+              {key}
+              <input
+                type="number"
+                step="0.01"
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+                value={Number(value.toFixed ? value.toFixed(2) : value)}
+                onChange={handleChange('sales', key)}
+              />
+            </label>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Inventory & Pricing</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-3">
+          {Object.entries(state.coefficients.inventory).map(([key, value]) => (
+            <label key={key} className="text-sm capitalize">
+              {key}
+              <input
+                type="number"
+                step="0.01"
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+                value={value}
+                onChange={handleChange('inventory', key)}
+              />
+            </label>
+          ))}
+          {Object.entries(state.coefficients.pricing).map(([key, value]) => (
+            <label key={key} className="text-sm capitalize">
+              {key}
+              <input
+                type="number"
+                step="0.01"
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 p-2"
+                value={value}
+                onChange={handleChange('pricing', key)}
+              />
+            </label>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ControlPanel;

--- a/dealership-sim/frontend/src/features/dashboard/Dashboard.tsx
+++ b/dealership-sim/frontend/src/features/dashboard/Dashboard.tsx
@@ -1,0 +1,96 @@
+import { GameState } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  BarChart,
+  Bar,
+  ResponsiveContainer,
+  Legend,
+  CartesianGrid,
+} from 'recharts';
+
+interface Props {
+  state: GameState;
+}
+
+const Dashboard = ({ state }: Props) => {
+  const cashSeries = state.dailyHistory.slice(-30).map((report) => ({ date: report.date.slice(-5), cash: report.cash }));
+  const salesSeries = state.dailyHistory.slice(-30).map((report) => ({ date: report.date.slice(-5), units: report.salesUnits }));
+  const serviceSeries = state.dailyHistory.slice(-30).map((report) => ({
+    date: report.date.slice(-5),
+    labor: report.serviceLaborHours,
+    parts: report.servicePartsRevenue,
+  }));
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Cash Balance</CardTitle>
+        </CardHeader>
+        <CardContent className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={cashSeries}>
+              <defs>
+                <linearGradient id="cashGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#38bdf8" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <XAxis dataKey="date" stroke="#94a3b8" />
+              <YAxis stroke="#94a3b8" />
+              <Tooltip contentStyle={{ background: '#0f172a', borderColor: '#1e293b' }} />
+              <Area type="monotone" dataKey="cash" stroke="#38bdf8" fillOpacity={1} fill="url(#cashGradient)" />
+            </AreaChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Units Sold (Last 30 days)</CardTitle>
+        </CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={salesSeries}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <XAxis dataKey="date" stroke="#94a3b8" />
+              <YAxis stroke="#94a3b8" />
+              <Tooltip contentStyle={{ background: '#0f172a', borderColor: '#1e293b' }} />
+              <Bar dataKey="units" fill="#2563eb" radius={[6, 6, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Service Mix</CardTitle>
+        </CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={serviceSeries} stackOffset="expand">
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <XAxis dataKey="date" stroke="#94a3b8" />
+              <YAxis stroke="#94a3b8" tickFormatter={(value) => `${Math.round(value * 100)}%`} />
+              <Tooltip
+                formatter={(value: number) => `${Math.round(value)} hrs`}
+                contentStyle={{ background: '#0f172a', borderColor: '#1e293b' }}
+              />
+              <Legend />
+              <Bar dataKey="labor" stackId="a" fill="#22d3ee" name="Labor Hours" />
+              <Bar dataKey="parts" stackId="a" fill="#38bdf8" name="Parts Revenue" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/dealership-sim/frontend/src/features/inventory/InventoryView.tsx
+++ b/dealership-sim/frontend/src/features/inventory/InventoryView.tsx
@@ -1,0 +1,80 @@
+import { GameState, Vehicle } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { useGameStore } from '../../state/useGameStore';
+
+interface Props {
+  state: GameState;
+}
+
+const InventoryView = ({ state }: Props) => {
+  const { acquireInventory } = useGameStore();
+
+  const grouped = state.inventory.reduce<Record<string, Vehicle[]>>((acc, vehicle) => {
+    acc[vehicle.status] = acc[vehicle.status] || [];
+    acc[vehicle.status].push(vehicle);
+    return acc;
+  }, {});
+
+  const ageBadge = (age: number) => {
+    if (age > 90) return <Badge variant="danger">Aged</Badge>;
+    if (age > 60) return <Badge variant="warning">60+</Badge>;
+    return <Badge variant="success">Fresh</Badge>;
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Acquire Inventory</CardTitle>
+          <CardDescription>Quickly top up desirable, balanced, or clearance inventory packs.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Button onClick={() => acquireInventory('desirable', 5)}>Desirable Pack (5)</Button>
+          <Button variant="outline" onClick={() => acquireInventory('neutral', 6)}>
+            Balanced Pack (6)
+          </Button>
+          <Button variant="outline" onClick={() => acquireInventory('undesirable', 6)}>
+            Value Pack (6)
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {(grouped['inStock'] || []).map((vehicle) => (
+          <Card key={vehicle.id}>
+            <CardHeader>
+              <CardTitle>
+                {vehicle.year} {vehicle.make} {vehicle.model}
+              </CardTitle>
+              <CardDescription>
+                Stock #{vehicle.stockNumber} · {vehicle.segment.toUpperCase()} · {vehicle.condition.toUpperCase()}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-2 text-sm text-slate-300">
+              <div>
+                <p>Asking</p>
+                <p className="text-lg font-semibold text-foreground">${Math.round(vehicle.asking).toLocaleString()}</p>
+              </div>
+              <div>
+                <p>Cost Basis</p>
+                <p className="text-lg font-semibold text-foreground">${Math.round(vehicle.cost + vehicle.reconCost).toLocaleString()}</p>
+              </div>
+              <div>
+                <p>Desirability</p>
+                <p className="text-lg font-semibold">{Math.round(vehicle.desirability)}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <p>Age: {vehicle.ageDays} days</p>
+                {ageBadge(vehicle.ageDays)}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default InventoryView;

--- a/dealership-sim/frontend/src/features/reports/ReportsView.tsx
+++ b/dealership-sim/frontend/src/features/reports/ReportsView.tsx
@@ -1,0 +1,71 @@
+import { GameState, MonthlyReport } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import { safeGet } from '../../lib/api';
+import { useState } from 'react';
+
+interface Props {
+  state: GameState;
+}
+
+const ReportsView = ({ state }: Props) => {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = async () => {
+    setExporting(true);
+    const data = await safeGet<{ month: string; daily: GameState['dailyHistory'] }>('/api/reports/export');
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `report-${data.month}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    setExporting(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Monthly Summary</CardTitle>
+          <CardDescription>High-level performance across sales, service, and customer experience.</CardDescription>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[700px] text-left text-sm text-slate-200">
+            <thead className="text-xs uppercase text-slate-400">
+              <tr>
+                <th className="pb-2">Month</th>
+                <th>Units</th>
+                <th>Total Gross</th>
+                <th>Avg Front</th>
+                <th>Avg Back</th>
+                <th>Fixed Coverage</th>
+                <th>CSI</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.monthlyReports.map((report) => (
+                <tr key={report.month} className="border-t border-slate-800/70">
+                  <td className="py-2">{report.month}</td>
+                  <td>{report.salesUnits}</td>
+                  <td>${Math.round(report.totalGross).toLocaleString()}</td>
+                  <td>${Math.round(report.avgFrontGross).toLocaleString()}</td>
+                  <td>${Math.round(report.avgBackGross).toLocaleString()}</td>
+                  <td>{(report.fixedCoverage * 100).toFixed(0)}%</td>
+                  <td>{report.csi.toFixed(1)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Button onClick={handleExport} disabled={exporting}>
+        {exporting ? 'Preparing export...' : 'Export Current Month JSON'}
+      </Button>
+    </div>
+  );
+};
+
+export default ReportsView;

--- a/dealership-sim/frontend/src/features/sales/SalesView.tsx
+++ b/dealership-sim/frontend/src/features/sales/SalesView.tsx
@@ -1,0 +1,106 @@
+import { GameState } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+
+interface Props {
+  state: GameState;
+}
+
+const moraleColor = (morale: number) => {
+  if (morale > 80) return 'success';
+  if (morale > 60) return 'default';
+  if (morale > 40) return 'warning';
+  return 'danger';
+};
+
+const SalesView = ({ state }: Props) => {
+  const latest = state.dailyHistory[state.dailyHistory.length - 1];
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Today&apos;s Funnel</CardTitle>
+          <CardDescription>Leads flow from marketing to sold deals.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid grid-cols-3 gap-3 text-center text-slate-200">
+          <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-4">
+            <p className="text-sm text-slate-400">Leads</p>
+            <p className="mt-2 text-3xl font-bold">{state.pipeline.leads}</p>
+          </div>
+          <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-4">
+            <p className="text-sm text-slate-400">Appointments</p>
+            <p className="mt-2 text-3xl font-bold">{state.pipeline.appointments}</p>
+          </div>
+          <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-4">
+            <p className="text-sm text-slate-400">Deals</p>
+            <p className="mt-2 text-3xl font-bold">{latest?.salesUnits ?? 0}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Advisor Roster</CardTitle>
+          <CardDescription>Morale directly influences close rates.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {state.advisors.map((advisor) => (
+            <div key={advisor.id} className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+              <div>
+                <p className="font-semibold text-foreground">{advisor.name}</p>
+                <p className="text-xs uppercase tracking-wide text-slate-400">{advisor.archetype}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={moraleColor(advisor.morale)}>Morale {Math.round(advisor.morale)}</Badge>
+                <p className="text-sm text-slate-300">Close {Math.round(advisor.skill.close)}</p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Recent Deals</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[600px] text-left text-sm text-slate-200">
+            <thead className="text-xs uppercase text-slate-400">
+              <tr>
+                <th className="pb-2">Date</th>
+                <th>Advisor</th>
+                <th>Vehicle</th>
+                <th>Sold Price</th>
+                <th>Front</th>
+                <th>Back</th>
+                <th>CSI Impact</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.recentDeals.slice(0, 10).map((deal) => {
+                const vehicle = state.inventory.find((item) => item.id === deal.vehicleId);
+                const advisor = state.advisors.find((item) => item.id === deal.advisorId);
+                return (
+                  <tr key={deal.id} className="border-t border-slate-800/70">
+                    <td className="py-2">{deal.date.slice(0, 10)}</td>
+                    <td>{advisor?.name ?? 'Unknown'}</td>
+                    <td>
+                      {vehicle ? `${vehicle.year} ${vehicle.make} ${vehicle.model}` : deal.vehicleId}
+                    </td>
+                    <td>${Math.round(deal.soldPrice).toLocaleString()}</td>
+                    <td>${Math.round(deal.frontGross).toLocaleString()}</td>
+                    <td>${Math.round(deal.backGross).toLocaleString()}</td>
+                    <td>{deal.csiImpact.toFixed(1)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default SalesView;

--- a/dealership-sim/frontend/src/features/service/ServiceView.tsx
+++ b/dealership-sim/frontend/src/features/service/ServiceView.tsx
@@ -1,0 +1,95 @@
+import { GameState } from '@dealership/shared';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+
+interface Props {
+  state: GameState;
+}
+
+const ServiceView = ({ state }: Props) => {
+  const latest = state.dailyHistory[state.dailyHistory.length - 1];
+  const comebackRate = latest?.serviceComebackRate ?? 0;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Technician Roster</CardTitle>
+          <CardDescription>Efficiency drives hours billed; morale keeps comebacks low.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {state.technicians.map((tech) => (
+            <div key={tech.id} className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+              <div>
+                <p className="font-semibold text-foreground">{tech.name}</p>
+                <p className="text-xs uppercase tracking-wide text-slate-400">{tech.archetype}</p>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-slate-300">
+                <Badge variant={tech.morale > 70 ? 'success' : tech.morale > 50 ? 'default' : 'warning'}>
+                  Morale {Math.round(tech.morale)}
+                </Badge>
+                <span>Eff {tech.efficiency.toFixed(2)}</span>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Service KPIs</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 text-sm text-slate-200">
+          <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-4">
+            <p className="text-slate-400">Labor Hours (Today)</p>
+            <p className="mt-2 text-2xl font-bold">{latest?.serviceLaborHours.toFixed(1) ?? 0}</p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-4">
+            <p className="text-slate-400">Parts Revenue (Today)</p>
+            <p className="mt-2 text-2xl font-bold">${Math.round(latest?.servicePartsRevenue ?? 0).toLocaleString()}</p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-4">
+            <p className="text-slate-400">Comeback Rate</p>
+            <p className="mt-2 text-2xl font-bold">{(comebackRate * 100).toFixed(1)}%</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Active Repair Orders</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          {state.serviceQueue.length === 0 && <p className="text-slate-400">Queue is clear. Great job!</p>}
+          {state.serviceQueue.map((ro) => (
+            <div key={ro.id} className="rounded-lg border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-200">
+              <p className="font-semibold">RO #{ro.id.split('-').at(-1)}</p>
+              <p>Status: {ro.status}</p>
+              <p>Labor: {ro.laborHours.toFixed(1)} hrs</p>
+              <p>Parts Est.: ${Math.round(ro.partsRevenue).toLocaleString()}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Recent Deliveries</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          {state.completedROs.slice(0, 8).map((ro) => (
+            <div key={ro.id} className="rounded-lg border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-200">
+              <p className="font-semibold">RO #{ro.id.split('-').at(-1)}</p>
+              <p>Tech: {state.technicians.find((tech) => tech.id === ro.techId)?.name ?? 'Team'}</p>
+              <p>Hours: {ro.laborHours.toFixed(1)}</p>
+              <p>Parts: ${Math.round(ro.partsRevenue).toLocaleString()}</p>
+              <p>CSI Impact: {ro.csiImpact.toFixed(1)}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ServiceView;

--- a/dealership-sim/frontend/src/lib/api.ts
+++ b/dealership-sim/frontend/src/lib/api.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE || 'http://localhost:4000',
+});
+
+export const safeGet = async <T>(url: string): Promise<T> => {
+  const response = await api.get<T>(url);
+  return response.data;
+};
+
+export const safePost = async <T>(url: string, data?: unknown): Promise<T> => {
+  const response = await api.post<T>(url, data);
+  return response.data;
+};
+
+export const safePut = async <T>(url: string, data?: unknown): Promise<T> => {
+  const response = await api.put<T>(url, data);
+  return response.data;
+};

--- a/dealership-sim/frontend/src/main.tsx
+++ b/dealership-sim/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/dealership-sim/frontend/src/state/useGameStore.ts
+++ b/dealership-sim/frontend/src/state/useGameStore.ts
@@ -1,0 +1,110 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { CONFIG_PRESETS, GameState, HealthCheckResult, Coefficients } from '@dealership/shared';
+import { safeGet, safePost, safePut } from '../lib/api';
+
+type AcquirePack = 'desirable' | 'neutral' | 'undesirable';
+
+interface GameStore {
+  gameState: GameState | null;
+  health: HealthCheckResult | null;
+  loading: boolean;
+  error?: string;
+  toasts: { id: string; title: string; description: string }[];
+  initialize: () => Promise<void>;
+  tick: (days?: number) => Promise<void>;
+  setPaused: (paused: boolean) => Promise<void>;
+  setSpeed: (speed: 1 | 5 | 30) => Promise<void>;
+  acquireInventory: (pack: AcquirePack, qty: number) => Promise<void>;
+  updateMarketing: (spend: number) => Promise<void>;
+  updateCoefficients: (patch: Partial<Coefficients>) => Promise<void>;
+  applyPreset: (id: string) => Promise<void>;
+  clearError: () => void;
+  dismissToast: (id: string) => void;
+}
+
+export const useGameStore = create<GameStore>()(
+  immer((set, get) => ({
+    gameState: null,
+    health: null,
+    loading: false,
+    toasts: [],
+    async initialize() {
+      set({ loading: true, error: undefined });
+      try {
+        const state = await safeGet<GameState>('/api/state');
+        const config = await safeGet<{ coefficients: Coefficients; health: HealthCheckResult }>('/api/config');
+        set({ gameState: state, health: config.health, loading: false });
+        get().pushNotifications(state.notifications);
+      } catch (error) {
+        set({ loading: false, error: 'Failed to load game state' });
+      }
+    },
+    async tick(days = 1) {
+      try {
+        const state = await safePost<GameState>('/api/tick', { days });
+        set((draft) => {
+          draft.gameState = state;
+        });
+        get().pushNotifications(state.notifications);
+      } catch (error) {
+        set({ error: 'Tick failed' });
+      }
+    },
+    async setPaused(paused) {
+      const state = await safePost<GameState>('/api/pause', { paused });
+      set({ gameState: state });
+    },
+    async setSpeed(speed) {
+      const state = await safePost<GameState>('/api/speed', { multiplier: speed });
+      set({ gameState: state });
+    },
+    async acquireInventory(pack, qty) {
+      try {
+        const state = await safePost<GameState>('/api/inventory/acquire', { pack, qty });
+        set({ gameState: state });
+        get().pushNotifications([`Acquired ${qty} vehicles (${pack})`]);
+      } catch (error) {
+        set({ error: 'Acquisition failed' });
+      }
+    },
+    async updateMarketing(spend) {
+      const state = await safePost<GameState>('/api/marketing/spend', { perDay: spend });
+      set({ gameState: state });
+    },
+    async updateCoefficients(patch) {
+      const response = await safePut<{ coefficients: Coefficients; health: HealthCheckResult }>('/api/config', patch);
+      set((draft) => {
+        if (draft.gameState) {
+          draft.gameState.coefficients = response.coefficients;
+        }
+        draft.health = response.health;
+      });
+    },
+    async applyPreset(id) {
+      const preset = CONFIG_PRESETS.find((item) => item.id === id);
+      if (!preset) return;
+      await get().updateCoefficients(preset.coefficients);
+    },
+    clearError() {
+      set({ error: undefined });
+    },
+    dismissToast(id) {
+      set((draft) => {
+        draft.toasts = draft.toasts.filter((toast) => toast.id !== id);
+      });
+    },
+    pushNotifications(messages: string[]) {
+      if (!messages?.length) return;
+      set((draft) => {
+        messages.forEach((message, index) => {
+          draft.toasts.push({
+            id: `${Date.now()}-${index}`,
+            title: 'Update',
+            description: message,
+          });
+        });
+      });
+    },
+  })) as unknown as GameStore & { pushNotifications: (messages: string[]) => void },
+);

--- a/dealership-sim/frontend/src/styles.css
+++ b/dealership-sim/frontend/src/styles.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/dealership-sim/frontend/tailwind.config.ts
+++ b/dealership-sim/frontend/tailwind.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#020817',
+        foreground: '#F8FAFC',
+        primary: {
+          DEFAULT: '#2563eb',
+          foreground: '#f8fafc',
+        },
+        muted: {
+          DEFAULT: '#1e293b',
+          foreground: '#94a3b8',
+        },
+        accent: {
+          DEFAULT: '#38bdf8',
+          foreground: '#0f172a',
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/dealership-sim/frontend/tsconfig.json
+++ b/dealership-sim/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src", "vite.config.ts", "tailwind.config.ts"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/dealership-sim/frontend/vite.config.ts
+++ b/dealership-sim/frontend/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_BASE || 'http://localhost:4000',
+        changeOrigin: true,
+      },
+    },
+  },
+  define: {
+    'process.env': {},
+  },
+});

--- a/dealership-sim/frontend/vitest.config.ts
+++ b/dealership-sim/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/dealership-sim/frontend/vitest.setup.ts
+++ b/dealership-sim/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/dealership-sim/package.json
+++ b/dealership-sim/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dealership-sim",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "pnpm@8.15.0",
+  "scripts": {
+    "dev": "pnpm -r --parallel dev",
+    "build": "pnpm -r build",
+    "test": "pnpm -r test",
+    "lint": "pnpm -r lint",
+    "format": "pnpm -r format"
+  },
+  "devDependencies": {
+    "concurrently": "8.2.2"
+  }
+}

--- a/dealership-sim/pnpm-workspace.yaml
+++ b/dealership-sim/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'shared'
+  - 'backend'
+  - 'frontend'

--- a/dealership-sim/shared/package.json
+++ b/dealership-sim/shared/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dealership/shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,json,md}'",
+    "test": "echo 'no tests in shared'"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "eslint": "8.56.0",
+    "@typescript-eslint/parser": "6.13.1",
+    "@typescript-eslint/eslint-plugin": "6.13.1",
+    "prettier": "3.1.1"
+  }
+}

--- a/dealership-sim/shared/src/constants.ts
+++ b/dealership-sim/shared/src/constants.ts
@@ -1,0 +1,96 @@
+import { Coefficients, ConfigPreset } from './types';
+
+export const DEFAULT_COEFFICIENTS: Coefficients = {
+  lead: {
+    basePerDay: 28,
+    marketingK: 0.45,
+    diminishingK: 0.35,
+  },
+  sales: {
+    baseClose: 0.05,
+    desirabilityWeight: 0.6,
+    priceGapWeight: -0.4,
+    archetypeWeight: 0.4,
+    economyWeight: 0.3,
+  },
+  pricing: {
+    variancePct: 0.035,
+    holdbackPct: 0.02,
+    pack: 450,
+    reconMean: 600,
+  },
+  inventory: {
+    minDaysSupply: 35,
+    bulkBuyUnits: 8,
+    auctionCostSpread: 0.08,
+  },
+  economy: {
+    volatility: 0.15,
+    incentiveImpact: 0.1,
+    interestRateBand: 0.03,
+  },
+  service: {
+    baseDemand: 55,
+    partsToLaborRatio: 0.8,
+    comebackPenalty: 6,
+  },
+  finance: {
+    avgBackGross: 950,
+    backGrossProb: 0.62,
+    cashLagDays: 2,
+  },
+  morale: {
+    trainingEffect: 6,
+    lowMoralePenalty: 0.08,
+  },
+  guardrails: {
+    targetReplacementGross: 3200,
+  },
+};
+
+export const CONFIG_PRESETS: ConfigPreset[] = [
+  {
+    id: 'easy',
+    name: 'Easy',
+    description: 'Plenty of demand and forgiving margins.',
+    coefficients: {
+      lead: { basePerDay: 36, marketingK: 0.55 },
+      sales: { baseClose: 0.08 },
+      pricing: { variancePct: 0.02 },
+      inventory: { minDaysSupply: 28 },
+      finance: { avgBackGross: 1100, backGrossProb: 0.7 },
+    },
+  },
+  {
+    id: 'balanced',
+    name: 'Balanced',
+    description: 'Default tuning used for internal balancing.',
+    coefficients: {},
+  },
+  {
+    id: 'hard',
+    name: 'Hard',
+    description: 'Tighter margins and colder demand.',
+    coefficients: {
+      lead: { basePerDay: 20, marketingK: 0.35 },
+      sales: { baseClose: 0.03 },
+      pricing: { variancePct: 0.05 },
+      inventory: { minDaysSupply: 45 },
+      finance: { avgBackGross: 800, backGrossProb: 0.5 },
+    },
+  },
+  {
+    id: 'wild',
+    name: 'Wild',
+    description: 'High volatility for testing edge cases.',
+    coefficients: {
+      economy: { volatility: 0.3, incentiveImpact: 0.18 },
+      pricing: { variancePct: 0.07 },
+    },
+  },
+];
+
+export const GAME_CONSTANTS = {
+  seasons: ['winter', 'spring', 'summer', 'fall'] as const,
+  segments: ['luxury', 'performance', 'suv', 'sedan', 'compact', 'ev', 'crossover', 'convertible'] as const,
+};

--- a/dealership-sim/shared/src/index.ts
+++ b/dealership-sim/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './constants';

--- a/dealership-sim/shared/src/types.ts
+++ b/dealership-sim/shared/src/types.ts
@@ -1,0 +1,240 @@
+export type VehicleCondition = 'new' | 'used' | 'cpo' | 'bev';
+export type VehicleStatus = 'inStock' | 'pending' | 'sold';
+
+export interface Vehicle {
+  id: string;
+  stockNumber: string;
+  year: number;
+  make: string;
+  model: string;
+  segment: 'luxury' | 'performance' | 'suv' | 'sedan' | 'compact' | 'ev' | 'crossover' | 'convertible';
+  cost: number;
+  floor: number;
+  asking: number;
+  ageDays: number;
+  desirability: number;
+  condition: VehicleCondition;
+  reconCost: number;
+  holdbackPct: number;
+  pack: number;
+  status: VehicleStatus;
+}
+
+export interface SkillProfile {
+  close: number;
+  gross: number;
+  csi: number;
+  speed: number;
+}
+
+export interface SalesAdvisor {
+  id: string;
+  name: string;
+  archetype: string;
+  skill: SkillProfile;
+  morale: number;
+  trained: string[];
+  active: boolean;
+}
+
+export interface Technician {
+  id: string;
+  name: string;
+  archetype: string;
+  efficiency: number;
+  comebackRate: number;
+  morale: number;
+  active: boolean;
+}
+
+export interface Customer {
+  id: string;
+  type: string;
+  priceSensitivity: number;
+  paymentFocus: number;
+  channel: 'walk-in' | 'web' | 'phone' | 'referral';
+  loyalty: number;
+  closeBias: number;
+  grossBias: number;
+  csiBias: number;
+  bevAffinity: number;
+}
+
+export interface Deal {
+  id: string;
+  vehicleId: string;
+  advisorId: string;
+  customerId: string;
+  date: string;
+  frontGross: number;
+  backGross: number;
+  totalGross: number;
+  csiImpact: number;
+  soldPrice: number;
+}
+
+export interface RepairOrder {
+  id: string;
+  techId: string;
+  date: string;
+  laborHours: number;
+  partsRevenue: number;
+  comeback: boolean;
+  csiImpact: number;
+}
+
+export interface EconomyState {
+  demandIndex: number;
+  interestRate: number;
+  incentiveLevel: number;
+  weatherFactor: number;
+  season: 'winter' | 'spring' | 'summer' | 'fall';
+}
+
+export interface MarketingState {
+  spendPerDay: number;
+  leadMultiplier: number;
+}
+
+export interface PipelineState {
+  leads: number;
+  appointments: number;
+  deals: number;
+}
+
+export interface ServiceQueueItem {
+  id: string;
+  techId?: string;
+  status: 'waiting' | 'inProgress' | 'complete';
+  laborHours: number;
+  partsRevenue: number;
+  comebackRisk: number;
+  completedOn?: string;
+}
+
+export interface Coefficients {
+  lead: {
+    basePerDay: number;
+    marketingK: number;
+    diminishingK: number;
+  };
+  sales: {
+    baseClose: number;
+    desirabilityWeight: number;
+    priceGapWeight: number;
+    archetypeWeight: number;
+    economyWeight: number;
+  };
+  pricing: {
+    variancePct: number;
+    holdbackPct: number;
+    pack: number;
+    reconMean: number;
+  };
+  inventory: {
+    minDaysSupply: number;
+    bulkBuyUnits: number;
+    auctionCostSpread: number;
+  };
+  economy: {
+    volatility: number;
+    incentiveImpact: number;
+    interestRateBand: number;
+  };
+  service: {
+    baseDemand: number;
+    partsToLaborRatio: number;
+    comebackPenalty: number;
+  };
+  finance: {
+    avgBackGross: number;
+    backGrossProb: number;
+    cashLagDays: number;
+  };
+  morale: {
+    trainingEffect: number;
+    lowMoralePenalty: number;
+  };
+  guardrails: {
+    targetReplacementGross: number;
+  };
+}
+
+export interface DailyReport {
+  date: string;
+  salesUnits: number;
+  frontGross: number;
+  backGross: number;
+  totalGross: number;
+  closingRate: number;
+  serviceLaborHours: number;
+  servicePartsRevenue: number;
+  serviceComebackRate: number;
+  cash: number;
+  marketingSpend: number;
+  moraleIndex: number;
+  csi: number;
+}
+
+export interface MonthlyReport {
+  month: string;
+  salesUnits: number;
+  frontGross: number;
+  backGross: number;
+  totalGross: number;
+  avgFrontGross: number;
+  avgBackGross: number;
+  closingRate: number;
+  inventoryStart: number;
+  inventoryEnd: number;
+  aged60Plus: number;
+  aged90Plus: number;
+  serviceLaborHours: number;
+  servicePartsRevenue: number;
+  comebackRate: number;
+  cashDelta: number;
+  advertisingROI: number;
+  fixedCoverage: number;
+  moraleTrend: number;
+  trainingCompletions: number;
+  csi: number;
+}
+
+export interface GameState {
+  day: number;
+  month: number;
+  year: number;
+  speed: 1 | 5 | 30;
+  paused: boolean;
+  cash: number;
+  inventory: Vehicle[];
+  advisors: SalesAdvisor[];
+  technicians: Technician[];
+  pipeline: PipelineState;
+  activeDeals: Deal[];
+  recentDeals: Deal[];
+  serviceQueue: ServiceQueueItem[];
+  completedROs: RepairOrder[];
+  marketing: MarketingState;
+  economy: EconomyState;
+  coefficients: Coefficients;
+  csi: number;
+  moraleIndex: number;
+  dailyHistory: DailyReport[];
+  monthlyReports: MonthlyReport[];
+  notifications: string[];
+}
+
+export interface HealthCheckResult {
+  starving: boolean;
+  expectedGross: number;
+  replacementGross: number;
+  message: string;
+}
+
+export interface ConfigPreset {
+  id: string;
+  name: string;
+  description: string;
+  coefficients: Partial<Coefficients>;
+}

--- a/dealership-sim/shared/tsconfig.json
+++ b/dealership-sim/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/dealership-sim/tsconfig.base.json
+++ b/dealership-sim/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a pnpm workspace with shared typings, backend simulation engine, and React frontend
- implement tick-based dealership engine with balancing controls, REST API, seed data, and guardrail tests
- build Tailwind + shadcn-style dashboard, control panel, inventory, sales, service, and reports screens with Zustand state

## Testing
- ⚠️ `pnpm install` *(fails: registry proxy blocked download of pnpm@8.15.0 via corepack)*

------
https://chatgpt.com/codex/tasks/task_e_68e18727909083229270de9453f55496